### PR TITLE
Feature: Ducktyping via C# 14 Extensions and Static Method Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,22 @@ internal readonly struct AddCalculator_ICalculator_Proxy : ICalculator
 
 public static class CalculatorManager_DuckTypingExtensions
 {
-    public static float HandleCalculate(this CalculatorManager target, AddCalculator handler, float a, float b)
+    extension (CalculatorManager target)
     {
-        return target.HandleCalculate(new AddCalculator_ICalculator_Proxy(handler), a, b);
+        public float HandleCalculate(AddCalculator handler, float a, float b)
+        {
+            return target.HandleCalculate(new AddCalculator_ICalculator_Proxy(handler), a, b);
+        }
     }
 }
 ```
 
 This ensures absolute zero-allocation overhead since the proxy is a `struct` (which will be boxed, but avoids the reflection setup entirely) and the extension method passes it right into the target.
 
+Static methods are also fully supported through C# 14 extension types! If `HandleCalculate` were a `static` method, it would generate `public static float HandleCalculate(...) { CalculatorManager.HandleCalculate(...); }` inside the extension type.
+
+> **Note:** Because NTypeForge now uses C# 14 extensions to power the duck typing, you will need to add `<LangVersion>preview</LangVersion>` to your `.csproj` file to enable the feature while it's in preview.
+
 ## About
 
-Experiments for zero-overhead structural duck typing support in C# 10.
+Experiments for zero-overhead structural duck typing support in C# 14.

--- a/src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs
+++ b/src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs
@@ -48,19 +48,9 @@ namespace NTypeForge.SourceGenerator
         // Check if any candidate failed because of an argument type mismatch where duck typing could help
         foreach (var candidate in symbolInfo.CandidateSymbols.OfType<IMethodSymbol>())
         {
-            // We only support generating extensions for instance methods or static methods
-            // Find the receiver type
-            ITypeSymbol? targetType = null;
-            if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
-            {
-                var receiverInfo = semanticModel.GetTypeInfo(memberAccess.Expression);
-                targetType = receiverInfo.Type;
-            }
-            else if (invocation.Expression is IdentifierNameSyntax)
-            {
-                // Implicit this
-                targetType = semanticModel.GetEnclosingSymbol(invocation.SpanStart)?.ContainingType;
-            }
+            // We support generating extensions for instance methods or static methods
+            // Find the receiver type: it's the class/struct defining the method.
+            ITypeSymbol? targetType = candidate.ContainingType;
 
             if (targetType == null) continue;
 
@@ -91,7 +81,8 @@ namespace NTypeForge.SourceGenerator
                             argType,
                             paramType,
                             i,
-                            candidate
+                            candidate,
+                            candidate.IsStatic
                         );
                     }
                 }
@@ -106,18 +97,30 @@ namespace NTypeForge.SourceGenerator
             if (candidates.IsDefaultOrEmpty)
                 return;
 
-            var generatedHints = new System.Collections.Generic.HashSet<string>();
-
-            foreach (var candidate in candidates)
+            // Group by the target type to avoid duplicate class names
+            foreach (var group in candidates.GroupBy(c => c.TargetType, SymbolEqualityComparer.Default))
             {
-                var matchResult = CheckStructuralMatch(candidate.ArgumentType, candidate.ExpectedInterfaceType);
-                if (matchResult.IsMatch)
+                var targetType = (ITypeSymbol)group.Key!;
+                var extensionsToGenerate = new System.Collections.Generic.List<(CandidateInvocation candidate, StructuralMatchResult matchResult)>();
+                var generatedHints = new System.Collections.Generic.HashSet<string>();
+
+                foreach (var candidate in group)
                 {
-                    var hintName = $"{candidate.TargetType.Name}_{candidate.OriginalMethod.Name}_{candidate.ArgumentType.Name}_DuckTyping.g.cs";
-                    if (generatedHints.Add(hintName))
+                    var matchResult = CheckStructuralMatch(candidate.ArgumentType, candidate.ExpectedInterfaceType);
+                    if (matchResult.IsMatch)
                     {
-                        GenerateProxyAndExtension(context, candidate, matchResult, hintName);
+                        // Ensure we don't generate the same extension method multiple times
+                        var methodHint = $"{candidate.OriginalMethod.Name}_{candidate.ArgumentType.Name}";
+                        if (generatedHints.Add(methodHint))
+                        {
+                            extensionsToGenerate.Add((candidate, matchResult));
+                        }
                     }
+                }
+
+                if (extensionsToGenerate.Count > 0)
+                {
+                    GenerateProxyAndExtension(context, targetType, extensionsToGenerate);
                 }
             }
         }
@@ -162,17 +165,11 @@ namespace NTypeForge.SourceGenerator
             return true;
         }
 
-        private static void GenerateProxyAndExtension(SourceProductionContext context, CandidateInvocation candidate, StructuralMatchResult matchResult, string hintName)
+        private static void GenerateProxyAndExtension(SourceProductionContext context, ITypeSymbol targetType, System.Collections.Generic.List<(CandidateInvocation candidate, StructuralMatchResult matchResult)> extensions)
         {
-            var sourceType = candidate.ArgumentType;
-            var interfaceType = candidate.ExpectedInterfaceType;
-            var targetType = candidate.TargetType;
-            var originalMethod = candidate.OriginalMethod;
-
-            var sourceTypeName = sourceType.Name;
-            var interfaceTypeName = interfaceType.Name;
-            var proxyStructName = $"{sourceTypeName}_{interfaceTypeName}_Proxy";
             var extensionClassName = $"{targetType.Name}_DuckTypingExtensions";
+            var targetNamespace = targetType.ContainingNamespace.IsGlobalNamespace ? "" : targetType.ContainingNamespace.ToDisplayString();
+            var targetFullName = targetType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
             var sb = new System.Text.StringBuilder();
 
@@ -180,101 +177,130 @@ namespace NTypeForge.SourceGenerator
             sb.AppendLine("using System;");
             sb.AppendLine();
 
-            var targetNamespace = targetType.ContainingNamespace.IsGlobalNamespace ? "" : targetType.ContainingNamespace.ToDisplayString();
             if (!string.IsNullOrEmpty(targetNamespace))
             {
                 sb.AppendLine($"namespace {targetNamespace}");
                 sb.AppendLine("{");
             }
 
-            // Generate Proxy Struct
-            var interfaceFullName = interfaceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            var sourceFullName = sourceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            // Generate Proxy Structs uniquely
+            var generatedProxies = new System.Collections.Generic.HashSet<string>();
 
-            sb.AppendLine($"    internal readonly struct {proxyStructName} : {interfaceFullName}");
-            sb.AppendLine("    {");
-            sb.AppendLine($"        private readonly {sourceFullName} _instance;");
-            sb.AppendLine();
-            sb.AppendLine($"        public {proxyStructName}({sourceFullName} instance)");
-            sb.AppendLine("        {");
-            sb.AppendLine("            _instance = instance;");
-            sb.AppendLine("        }");
-            sb.AppendLine();
-
-            foreach (var method in matchResult.MatchedMethods)
+            foreach (var item in extensions)
             {
-                var returnTypeStr = method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-                var parametersStr = string.Join(", ", method.Parameters.Select(p => $"{p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} {p.Name}"));
-                var argsStr = string.Join(", ", method.Parameters.Select(p => p.Name));
+                var sourceType = item.candidate.ArgumentType;
+                var interfaceType = item.candidate.ExpectedInterfaceType;
 
-                sb.AppendLine($"        public {returnTypeStr} {method.Name}({parametersStr})");
-                sb.AppendLine("        {");
-                if (method.ReturnType.SpecialType == SpecialType.System_Void)
-                {
-                    sb.AppendLine($"            _instance.{method.Name}({argsStr});");
-                }
-                else
-                {
-                    sb.AppendLine($"            return _instance.{method.Name}({argsStr});");
-                }
-                sb.AppendLine("        }");
-            }
-            sb.AppendLine("    }");
-            sb.AppendLine();
+                var sourceTypeName = sourceType.Name;
+                var interfaceTypeName = interfaceType.Name;
+                var proxyStructName = $"{sourceTypeName}_{interfaceTypeName}_Proxy";
 
-            // Generate Extension Method
-            var targetFullName = targetType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-
-            // Build parameters for the extension method
-            var extParams = new System.Collections.Generic.List<string>();
-            extParams.Add($"this {targetFullName} target");
-
-            for (int i = 0; i < originalMethod.Parameters.Length; i++)
-            {
-                var p = originalMethod.Parameters[i];
-                if (i == candidate.ArgumentIndex)
+                if (generatedProxies.Add(proxyStructName))
                 {
-                    extParams.Add($"{sourceFullName} {p.Name}");
-                }
-                else
-                {
-                    extParams.Add($"{p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} {p.Name}");
+                    var interfaceFullName = interfaceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                    var sourceFullName = sourceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+                    sb.AppendLine($"    internal readonly struct {proxyStructName} : {interfaceFullName}");
+                    sb.AppendLine("    {");
+                    sb.AppendLine($"        private readonly {sourceFullName} _instance;");
+                    sb.AppendLine();
+                    sb.AppendLine($"        public {proxyStructName}({sourceFullName} instance)");
+                    sb.AppendLine("        {");
+                    sb.AppendLine("            _instance = instance;");
+                    sb.AppendLine("        }");
+                    sb.AppendLine();
+
+                    foreach (var method in item.matchResult.MatchedMethods)
+                    {
+                        var returnTypeStr = method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                        var parametersStr = string.Join(", ", method.Parameters.Select(p => $"{p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} {p.Name}"));
+                        var argsStr = string.Join(", ", method.Parameters.Select(p => p.Name));
+
+                        sb.AppendLine($"        public {returnTypeStr} {method.Name}({parametersStr})");
+                        sb.AppendLine("        {");
+                        if (method.ReturnType.SpecialType == SpecialType.System_Void)
+                        {
+                            sb.AppendLine($"            _instance.{method.Name}({argsStr});");
+                        }
+                        else
+                        {
+                            sb.AppendLine($"            return _instance.{method.Name}({argsStr});");
+                        }
+                        sb.AppendLine("        }");
+                    }
+                    sb.AppendLine("    }");
+                    sb.AppendLine();
                 }
             }
 
-            var extParamsStr = string.Join(", ", extParams);
-            var extReturnTypeStr = originalMethod.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            var methodName = originalMethod.Name;
-
+            // Generate Extension Type
             sb.AppendLine($"    public static class {extensionClassName}");
             sb.AppendLine("    {");
-            sb.AppendLine($"        public static {extReturnTypeStr} {methodName}({extParamsStr})");
+            var receiverTargetName = "target";
+            sb.AppendLine($"        extension ({targetFullName} {receiverTargetName})");
             sb.AppendLine("        {");
 
-            // Build arguments for calling the original method
-            var callArgs = new System.Collections.Generic.List<string>();
-            for (int i = 0; i < originalMethod.Parameters.Length; i++)
+            foreach (var item in extensions)
             {
-                var p = originalMethod.Parameters[i];
-                if (i == candidate.ArgumentIndex)
+                var candidate = item.candidate;
+                var originalMethod = candidate.OriginalMethod;
+                var sourceType = candidate.ArgumentType;
+                var interfaceType = candidate.ExpectedInterfaceType;
+                var proxyStructName = $"{sourceType.Name}_{interfaceType.Name}_Proxy";
+                var sourceFullName = sourceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+                // Build parameters for the extension method
+                var extParams = new System.Collections.Generic.List<string>();
+
+                for (int i = 0; i < originalMethod.Parameters.Length; i++)
                 {
-                    callArgs.Add($"new {proxyStructName}({p.Name})");
+                    var p = originalMethod.Parameters[i];
+                    if (i == candidate.ArgumentIndex)
+                    {
+                        extParams.Add($"{sourceFullName} {p.Name}");
+                    }
+                    else
+                    {
+                        extParams.Add($"{p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} {p.Name}");
+                    }
+                }
+
+                var extParamsStr = string.Join(", ", extParams);
+                var extReturnTypeStr = originalMethod.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+                var methodName = originalMethod.Name;
+                var isStaticStr = candidate.IsStatic ? "static " : "";
+                var receiverStr = candidate.IsStatic ? targetFullName : receiverTargetName;
+
+                sb.AppendLine($"            public {isStaticStr}{extReturnTypeStr} {methodName}({extParamsStr})");
+                sb.AppendLine("            {");
+
+                // Build arguments for calling the original method
+                var callArgs = new System.Collections.Generic.List<string>();
+                for (int i = 0; i < originalMethod.Parameters.Length; i++)
+                {
+                    var p = originalMethod.Parameters[i];
+                    if (i == candidate.ArgumentIndex)
+                    {
+                        callArgs.Add($"new {proxyStructName}({p.Name})");
+                    }
+                    else
+                    {
+                        callArgs.Add(p.Name);
+                    }
+                }
+
+                var callArgsStr = string.Join(", ", callArgs);
+
+                if (originalMethod.ReturnType.SpecialType == SpecialType.System_Void)
+                {
+                    sb.AppendLine($"                {receiverStr}.{methodName}({callArgsStr});");
                 }
                 else
                 {
-                    callArgs.Add(p.Name);
+                    sb.AppendLine($"                return {receiverStr}.{methodName}({callArgsStr});");
                 }
-            }
 
-            var callArgsStr = string.Join(", ", callArgs);
-
-            if (originalMethod.ReturnType.SpecialType == SpecialType.System_Void)
-            {
-                sb.AppendLine($"            target.{methodName}({callArgsStr});");
-            }
-            else
-            {
-                sb.AppendLine($"            return target.{methodName}({callArgsStr});");
+                sb.AppendLine("            }");
             }
 
             sb.AppendLine("        }");
@@ -285,7 +311,7 @@ namespace NTypeForge.SourceGenerator
                 sb.AppendLine("}");
             }
 
-            context.AddSource(hintName, sb.ToString());
+            context.AddSource($"{targetType.Name}_DuckTyping.g.cs", sb.ToString());
         }
     }
 }

--- a/src/NTypeForge.SourceGenerator/Models/CandidateInvocation.cs
+++ b/src/NTypeForge.SourceGenerator/Models/CandidateInvocation.cs
@@ -13,6 +13,7 @@ namespace NTypeForge.SourceGenerator.Models
         public ITypeSymbol ExpectedInterfaceType;
         public int ArgumentIndex;
         public IMethodSymbol OriginalMethod;
+        public bool IsStatic;
 
         public CandidateInvocation(
             InvocationExpressionSyntax invocation,
@@ -21,7 +22,8 @@ namespace NTypeForge.SourceGenerator.Models
             ITypeSymbol argumentType,
             ITypeSymbol expectedInterfaceType,
             int argumentIndex,
-            IMethodSymbol originalMethod)
+            IMethodSymbol originalMethod,
+            bool isStatic)
         {
             Invocation = invocation;
             MethodName = methodName;
@@ -30,6 +32,7 @@ namespace NTypeForge.SourceGenerator.Models
             ExpectedInterfaceType = expectedInterfaceType;
             ArgumentIndex = argumentIndex;
             OriginalMethod = originalMethod;
+            IsStatic = isStatic;
         }
     }
 }

--- a/tests/NTypeForge.Tests/DuckTypingTests.cs
+++ b/tests/NTypeForge.Tests/DuckTypingTests.cs
@@ -21,6 +21,11 @@ public class CalculatorManager
     {
         return handler.Calculate(a, b);
     }
+
+    public static float HandleCalculateStatic(ICalculator handler, float a, float b)
+    {
+        return handler.Calculate(a, b) * 2;
+    }
 }
 
 public class DuckTypingTests
@@ -36,5 +41,17 @@ public class DuckTypingTests
         var result = manager.HandleCalculate(handler, 2, 3);
 
         Assert.Equal(5f, result);
+    }
+
+    [Fact]
+    public void CanDuckTypeAddCalculatorToICalculatorUsingStaticMethod()
+    {
+        var handler = new AddCalculator();
+
+        // This method does not exist natively on CalculatorManager that takes AddCalculator
+        // The source generator will create an extension method to handle it.
+        var result = CalculatorManager.HandleCalculateStatic(handler, 2, 3);
+
+        Assert.Equal(10f, result);
     }
 }

--- a/tests/NTypeForge.Tests/NTypeForge.Tests.csproj
+++ b/tests/NTypeForge.Tests/NTypeForge.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Implemented support for C# 14 extension types and added support for static methods in the duck-typing generator. Fixed a bug related to grouping candidate invocations for the same target class to ensure accurate code generation.

---
*PR created automatically by Jules for task [7431568189367983591](https://jules.google.com/task/7431568189367983591) started by @timonkrebs*