### PR TITLE
🧪 test: add parameter mismatch edge case tests

### DIFF
--- a/tests/NTypeForge.Generator.Tests/DiagnosticTests.cs
+++ b/tests/NTypeForge.Generator.Tests/DiagnosticTests.cs
@@ -145,6 +145,42 @@ public class DiagnosticTests
         Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
     }
 
+    // A concrete method with different parameter types from the interface method cannot satisfy it.
+    [Fact]
+    public void NTF001_WhenParameterTypeDiffers()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface I { void Do(int a); }
+                public class C { public void Do(string a) {} }
+                public class U { public void M() { var x = new C().Duck<I>(); } }
+            }
+            """;
+
+        Assert.Equal(1, GeneratorTestHarness.GetGeneratorDiagnostics(source).CountDiagnostics("NTF001"));
+        Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    // A concrete method with a different parameter count from the interface method cannot satisfy it.
+    [Fact]
+    public void NTF001_WhenParameterCountDiffers()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface I { void Do(int a, int b); }
+                public class C { public void Do(int a) {} }
+                public class U { public void M() { var x = new C().Duck<I>(); } }
+            }
+            """;
+
+        Assert.Equal(1, GeneratorTestHarness.GetGeneratorDiagnostics(source).CountDiagnostics("NTF001"));
+        Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
     // Regression: a concrete with a *private* setter must not be treated as satisfying a `{ get; set; }`
     // requirement. The proxy would emit `_instance.Value = value` against an inaccessible setter
     // (CS0272). Expect a clean NTF001 with no emitted compile errors instead.


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for parameter mismatch matching in methods. Specifically, parameter count and parameter type mismatches.
📊 **Coverage:** The scenarios now tested are a concrete method with a different parameter count from the interface method, and a concrete method with a different parameter type from the interface method.
✨ **Result:** Test coverage has been increased to cover structural mismatches when parameters differ in types and/or count.

---
*PR created automatically by Jules for task [1277736806844077200](https://jules.google.com/task/1277736806844077200) started by @timonkrebs*