### PR TITLE
Support multiple duck-typed arguments in a single method call

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ var calculator = new AddCalculator();
 float result = CalculatorManager.HandleCalculateStatic(calculator, 2, 3);
 ```
 
+If a call needs *several* arguments bridged at once, they are all ducked together —
+the generated overload replaces every duck-typed parameter, and each argument gets
+its own proxy:
+
+```cs
+// HandleBoth(ICalculator calculator, ILogger logger, float a, float b)
+manager.HandleBoth(new AddCalculator(), new ConsoleLogger(), 10, 20); // ✅ both arguments ducked
+```
+
 ### 2. Create a proxy explicitly with `Duck<T>()`
 
 When you want the interface value itself (to store it, return it, or pass it
@@ -300,7 +309,9 @@ public static class CalculatorManager_DuckTypingExtensions
 The names above are simplified: the real proxy and extension-class names carry a
 stable hash suffix for uniqueness. And when the ducked argument's static type is an
 *interface* (rather than a concrete type as here), the forwarding method first emits
-`TryUnbox` branches to unwrap an existing proxy before re-wrapping it.
+`TryUnbox` branches to unwrap an existing proxy before re-wrapping it. When several
+arguments are ducked in the same call, the one forwarding method replaces every
+duck-typed parameter and wraps each argument in its own proxy.
 
 The generated pipeline is fully cacheable: each call site is reduced to a
 value-equatable model (strings/enums only — no symbols held), so edits that don't

--- a/src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs
+++ b/src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs
@@ -16,6 +16,23 @@ namespace NTypeForge.SourceGenerator
     // of the model. Returns null for invocations that are not duck-typing sites.
     internal static class CandidateAnalyzer
     {
+        // A ducked argument still in symbol form, resolved per argument before model assembly.
+        private readonly struct DuckedArgSite
+        {
+            public readonly ITypeSymbol ArgType;
+            public readonly ITypeSymbol UnderlyingType;
+            public readonly ITypeSymbol InterfaceType;
+            public readonly int EmittedIndex;
+
+            public DuckedArgSite(ITypeSymbol argType, ITypeSymbol underlyingType, ITypeSymbol interfaceType, int emittedIndex)
+            {
+                ArgType = argType;
+                UnderlyingType = underlyingType;
+                InterfaceType = interfaceType;
+                EmittedIndex = emittedIndex;
+            }
+        }
+
         public static CandidateModel? GetCandidate(GeneratorSyntaxContext context)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
@@ -26,7 +43,7 @@ namespace NTypeForge.SourceGenerator
             if (duckCall != null) return duckCall;
 
             // A call that bound successfully needs no duck typing; only a failed overload
-            // resolution (Symbol == null, with candidates) can be rescued by a generated proxy.
+            // resolution (Symbol == null, with candidates) can be rescued by generated proxies.
             if (symbolInfo.Symbol != null || symbolInfo.CandidateSymbols.Length == 0) return null;
 
             return TryGetMethodArgumentDuck(invocation, semanticModel, symbolInfo);
@@ -141,9 +158,9 @@ namespace NTypeForge.SourceGenerator
             if (AlreadyImplements(semanticModel, argType, targetInterface)) return null;
 
             return BuildModel(
-                invocation, target: argType, argType: argType, underlyingType: underlyingType,
-                interfaceType: targetInterface, argumentIndex: 0, isStatic: false, isDuckCall: true,
-                originalMethod: null);
+                invocation, target: argType,
+                duckedArgs: new[] { new DuckedArgSite(argType, underlyingType, targetInterface, emittedIndex: 0) },
+                isStatic: false, isDuckCall: true, originalMethod: null);
         }
 
         private static bool AlreadyImplements(SemanticModel semanticModel, ITypeSymbol type, ITypeSymbol interfaceType)
@@ -171,42 +188,68 @@ namespace NTypeForge.SourceGenerator
             return memberAccess.Expression;
         }
 
-        // A failed call whose argument could implicitly become an interface parameter via a proxy.
-        // We rewire only when the call has exactly one duckable interpretation. With more than one,
-        // silently choosing a single (overload, argument) would be non-deterministic and could bind
-        // the call to the wrong overload, so we leave the original (still-failing) call for the
-        // compiler to report - which is also what suppresses the NTF003 near-miss on ambiguous sites.
+        // A failed call whose arguments could implicitly become interface parameters via proxies.
+        // Within one overload, every duckable argument is ducked together (each one that fails to
+        // convert must be replaced for the forwarded call to bind), so the overload's whole set of
+        // duckable arguments is a single interpretation. We rewire only when the call has exactly
+        // one duckable interpretation. With more than one, silently choosing a single overload
+        // would be non-deterministic and could bind the call to the wrong one, so we leave the
+        // original (still-failing) call for the compiler to report - which is also what suppresses
+        // the NTF003 near-miss on ambiguous sites.
         private static CandidateModel? TryGetMethodArgumentDuck(
             InvocationExpressionSyntax invocation, SemanticModel semanticModel, SymbolInfo symbolInfo)
         {
             if (invocation.Expression is not MemberAccessExpressionSyntax) return null;
 
-            var sites = DistinctInterpretations(CollectDuckableArgumentSites(invocation, semanticModel, symbolInfo));
-            if (sites.Count != 1) return null;
+            var interpretations = DistinctInterpretations(CollectDuckableInterpretations(invocation, semanticModel, symbolInfo));
+            if (interpretations.Count != 1) return null;
 
-            var (candidate, paramIndex, syntaxIndex) = sites[0];
-            var argType = semanticModel.GetTypeInfo(invocation.ArgumentList.Arguments[syntaxIndex].Expression).Type!;
-            var underlyingType = GetUnderlyingType(argType);
+            var (candidate, args) = interpretations[0];
             var target = GetForwardingTarget(invocation, semanticModel, candidate);
             if (target == null ||
                 ContainsTypeParameter(target) ||
-                ContainsTypeParameter(argType) ||
-                ContainsTypeParameter(underlyingType) ||
-                ContainsTypeParameter(candidate.Parameters[paramIndex].Type) ||
                 !IsUsableFromGeneratedTopLevelCode(candidate.ContainingType!) ||
-                !IsUsableFromGeneratedTopLevelCode(target) ||
-                !IsUsableFromGeneratedTopLevelCode(argType) ||
-                !IsUsableFromGeneratedTopLevelCode(underlyingType) ||
-                !IsUsableFromGeneratedTopLevelCode(candidate.Parameters[paramIndex].Type))
+                !IsUsableFromGeneratedTopLevelCode(target))
                 return null;
 
+            var duckedArgs = ResolveDuckedArgSites(invocation, semanticModel, candidate, args);
+            if (duckedArgs == null) return null;
+
             return BuildModel(
-                invocation, target: target, argType: argType,
-                underlyingType: underlyingType, interfaceType: candidate.Parameters[paramIndex].Type,
-                argumentIndex: EmittedParameterIndex(candidate, paramIndex),
+                invocation, target: target, duckedArgs,
                 isStatic: candidate.IsStatic && !IsExtensionLike(candidate),
                 isDuckCall: false,
                 originalMethod: candidate);
+        }
+
+        // Resolves each duckable (parameter, argument) pair of the chosen overload to its symbol
+        // triple, ordered by emitted parameter index so the model is independent of named-argument
+        // order. Null when any argument involves a type the generated code could not utter (an
+        // open type parameter or an inaccessible type) - the site is then left alone as a whole,
+        // since a forwarding method missing one ducked parameter could never bind.
+        private static List<DuckedArgSite>? ResolveDuckedArgSites(
+            InvocationExpressionSyntax invocation, SemanticModel semanticModel, IMethodSymbol candidate,
+            IReadOnlyList<(int ParamIndex, int SyntaxIndex)> args)
+        {
+            var resolved = new List<DuckedArgSite>(args.Count);
+            foreach (var (paramIndex, syntaxIndex) in args)
+            {
+                var argType = semanticModel.GetTypeInfo(invocation.ArgumentList.Arguments[syntaxIndex].Expression).Type!;
+                var underlyingType = GetUnderlyingType(argType);
+                var interfaceType = candidate.Parameters[paramIndex].Type;
+                if (ContainsTypeParameter(argType) ||
+                    ContainsTypeParameter(underlyingType) ||
+                    ContainsTypeParameter(interfaceType) ||
+                    !IsUsableFromGeneratedTopLevelCode(argType) ||
+                    !IsUsableFromGeneratedTopLevelCode(underlyingType) ||
+                    !IsUsableFromGeneratedTopLevelCode(interfaceType))
+                    return null;
+
+                resolved.Add(new DuckedArgSite(argType, underlyingType, interfaceType, EmittedParameterIndex(candidate, paramIndex)));
+            }
+
+            resolved.Sort((a, b) => a.EmittedIndex.CompareTo(b.EmittedIndex));
+            return resolved;
         }
 
         private static bool IsExtensionLike(IMethodSymbol method)
@@ -232,61 +275,64 @@ namespace NTypeForge.SourceGenerator
         private static int EmittedParameterIndex(IMethodSymbol candidate, int paramIndex)
             => HasExplicitExtensionReceiverParameter(candidate) ? paramIndex - 1 : paramIndex;
 
-        // Collapses (overload, argument) sites that would generate the same forwarding method - an
-        // override and the base it hides, or a symbol Roslyn lists more than once - so they don't
-        // count as a false ambiguity. Genuinely distinct interpretations (different target interface
-        // or different remaining parameters) survive as separate entries.
-        private static List<(IMethodSymbol Candidate, int ParamIndex, int SyntaxIndex)> DistinctInterpretations(
-            List<(IMethodSymbol Candidate, int ParamIndex, int SyntaxIndex)> sites)
+        // Collapses interpretations that would generate the same forwarding method - an override
+        // and the base it hides, or a symbol Roslyn lists more than once - so they don't count as
+        // a false ambiguity. Genuinely distinct interpretations (different target interfaces or
+        // different remaining parameters) survive as separate entries.
+        private static List<(IMethodSymbol Candidate, List<(int ParamIndex, int SyntaxIndex)> Args)> DistinctInterpretations(
+            List<(IMethodSymbol Candidate, List<(int ParamIndex, int SyntaxIndex)> Args)> interpretations)
         {
-            // Nothing to dedup with 0 or 1 sites (the common case); skip the HashSet and key strings.
-            if (sites.Count <= 1) return sites;
+            // Nothing to dedup with 0 or 1 interpretations (the common case); skip the HashSet and
+            // key strings.
+            if (interpretations.Count <= 1) return interpretations;
 
             var seen = new HashSet<string>(StringComparer.Ordinal);
-            var result = new List<(IMethodSymbol Candidate, int ParamIndex, int SyntaxIndex)>();
-            foreach (var site in sites)
+            var result = new List<(IMethodSymbol Candidate, List<(int ParamIndex, int SyntaxIndex)> Args)>();
+            foreach (var interpretation in interpretations)
             {
-                if (seen.Add(InterpretationKey(site.Candidate, site.ParamIndex))) result.Add(site);
+                if (seen.Add(InterpretationKey(interpretation.Candidate, interpretation.Args))) result.Add(interpretation);
             }
             return result;
         }
 
         // Identifies the forwarding method an interpretation would emit: its declaring type, which
-        // argument is ducked, and the method's canonical signature key. Reusing MethodSig.DedupKey
+        // arguments are ducked, and the method's canonical signature key. Reusing MethodSig.DedupKey
         // (name + arity + full parameter shape incl. ref kinds + constraints, generics-normalized)
         // keeps this notion of "same method" from drifting from the rest of the generator and folds
         // in cases a hand-rolled key missed - e.g. two overloads differing only by a ref kind, or two
         // same-signature methods on different declaring types. Equal keys are interchangeable;
         // differing keys are a real ambiguity the user must resolve.
-        private static string InterpretationKey(IMethodSymbol candidate, int argIndex)
-            => $"{SymbolNames.Fq(candidate.ContainingType)}|{argIndex}|{MemberSignatures.ToMethodSig(candidate).DedupKey}";
+        private static string InterpretationKey(IMethodSymbol candidate, List<(int ParamIndex, int SyntaxIndex)> args)
+            => $"{SymbolNames.Fq(candidate.ContainingType)}|{string.Join(",", args.Select(a => a.ParamIndex))}|{MemberSignatures.ToMethodSig(candidate).DedupKey}";
 
-        private static List<(IMethodSymbol Candidate, int ParamIndex, int SyntaxIndex)> CollectDuckableArgumentSites(
+        private static List<(IMethodSymbol Candidate, List<(int ParamIndex, int SyntaxIndex)> Args)> CollectDuckableInterpretations(
             InvocationExpressionSyntax invocation, SemanticModel semanticModel, SymbolInfo symbolInfo)
         {
-            var sites = new List<(IMethodSymbol, int, int)>();
+            var interpretations = new List<(IMethodSymbol, List<(int, int)>)>();
             foreach (var candidate in symbolInfo.CandidateSymbols.OfType<IMethodSymbol>())
             {
                 if (candidate.ContainingType == null) continue;
                 var arguments = invocation.ArgumentList.Arguments;
                 if (!TryMapArgumentsToParameters(arguments, candidate, out var parameterIndices)) continue;
 
-                AddDuckableArgIndices(semanticModel, candidate, arguments, parameterIndices, sites);
+                var args = CollectDuckableArgs(semanticModel, candidate, arguments, parameterIndices);
+                if (args.Count > 0) interpretations.Add((candidate, args));
             }
-            return sites;
+            return interpretations;
         }
 
-        private static void AddDuckableArgIndices(
+        private static List<(int ParamIndex, int SyntaxIndex)> CollectDuckableArgs(
             SemanticModel semanticModel, IMethodSymbol candidate,
-            SeparatedSyntaxList<ArgumentSyntax> arguments, IReadOnlyList<int> parameterIndices,
-            List<(IMethodSymbol, int, int)> sites)
+            SeparatedSyntaxList<ArgumentSyntax> arguments, IReadOnlyList<int> parameterIndices)
         {
+            var args = new List<(int, int)>();
             for (int syntaxIndex = 0; syntaxIndex < arguments.Count; syntaxIndex++)
             {
                 var paramIndex = parameterIndices[syntaxIndex];
                 if (IsDuckableArgument(semanticModel, candidate, arguments, syntaxIndex, paramIndex))
-                    sites.Add((candidate, paramIndex, syntaxIndex));
+                    args.Add((paramIndex, syntaxIndex));
             }
+            return args;
         }
 
         private static bool IsDuckableArgument(
@@ -396,21 +442,12 @@ namespace NTypeForge.SourceGenerator
         private static CandidateModel BuildModel(
             InvocationExpressionSyntax invocation,
             ITypeSymbol target,
-            ITypeSymbol argType,
-            ITypeSymbol underlyingType,
-            ITypeSymbol interfaceType,
-            int argumentIndex,
+            IReadOnlyList<DuckedArgSite> duckedArgs,
             bool isStatic,
             bool isDuckCall,
             IMethodSymbol? originalMethod)
         {
-            var requirements = InterfaceRequirementsAnalyzer.Analyze(interfaceType);
-
-            var surface = SurfaceAnalyzer.BuildSurfaceCompatKeys(underlyingType);
-            var surfaceSet = new HashSet<string>(surface, StringComparer.Ordinal);
-
-            bool isSelfMatch = StructuralMatch.IsSatisfiedBy(
-                requirements.Methods, requirements.Properties, requirements.Indexers, requirements.Events, surfaceSet);
+            var argModels = duckedArgs.Select(BuildDuckedArg).ToList();
 
             var originalDefinition = originalMethod == null ? null : OriginalExtensionDefinition(originalMethod);
             var unconstructedMethod = originalDefinition?.OriginalDefinition;
@@ -428,16 +465,7 @@ namespace NTypeForge.SourceGenerator
                 targetMinimalName: SymbolNames.MinimalName(target),
                 targetIsInterface: target.TypeKind == TypeKind.Interface,
                 targetIsPublic: IsEffectivelyPublic(target),
-                argumentIsInterface: argType.TypeKind == TypeKind.Interface,
-                argumentFq: SymbolNames.Fq(argType),
-                underlyingFq: SymbolNames.Fq(underlyingType),
-                underlyingNamespace: SymbolNames.NamespaceOf(underlyingType),
-                underlyingMinimalName: SymbolNames.MinimalName(underlyingType),
-                underlyingIsInterface: underlyingType.TypeKind == TypeKind.Interface,
-                underlyingBaseDepth: SymbolNames.BaseTypeDepth(underlyingType),
-                interfaceFq: SymbolNames.Fq(interfaceType),
-                interfaceMinimalName: SymbolNames.MinimalName(interfaceType),
-                argumentIndex: argumentIndex,
+                duckedArgs: argModels,
                 isStatic: isStatic,
                 isDuckCall: isDuckCall,
                 originalMethodName: originalMethod?.Name ?? "",
@@ -449,16 +477,39 @@ namespace NTypeForge.SourceGenerator
                 originalArity: originalSig?.Arity ?? 0,
                 originalTypeParameters: originalSig?.TypeParameters ?? Array.Empty<string>(),
                 originalConstraints: originalSig?.Constraints ?? Array.Empty<string>(),
+                diagFilePath: loc.SourceTree?.FilePath,
+                diagSpan: loc.SourceSpan,
+                diagLineSpan: loc.GetLineSpan().Span);
+        }
+
+        private static DuckedArgModel BuildDuckedArg(DuckedArgSite site)
+        {
+            var requirements = InterfaceRequirementsAnalyzer.Analyze(site.InterfaceType);
+
+            var surface = SurfaceAnalyzer.BuildSurfaceCompatKeys(site.UnderlyingType);
+            var surfaceSet = new HashSet<string>(surface, StringComparer.Ordinal);
+
+            bool isSelfMatch = StructuralMatch.IsSatisfiedBy(
+                requirements.Methods, requirements.Properties, requirements.Indexers, requirements.Events, surfaceSet);
+
+            return new DuckedArgModel(
+                argumentIndex: site.EmittedIndex,
+                argumentIsInterface: site.ArgType.TypeKind == TypeKind.Interface,
+                argumentFq: SymbolNames.Fq(site.ArgType),
+                underlyingFq: SymbolNames.Fq(site.UnderlyingType),
+                underlyingNamespace: SymbolNames.NamespaceOf(site.UnderlyingType),
+                underlyingMinimalName: SymbolNames.MinimalName(site.UnderlyingType),
+                underlyingIsInterface: site.UnderlyingType.TypeKind == TypeKind.Interface,
+                underlyingBaseDepth: SymbolNames.BaseTypeDepth(site.UnderlyingType),
+                interfaceFq: SymbolNames.Fq(site.InterfaceType),
+                interfaceMinimalName: SymbolNames.MinimalName(site.InterfaceType),
                 methodRequirements: requirements.Methods,
                 propertyRequirements: requirements.Properties,
                 indexerRequirements: requirements.Indexers,
                 eventRequirements: requirements.Events,
                 underlyingSurfaceCompatKeys: surface,
                 isSelfMatch: isSelfMatch,
-                unsupportedMemberName: requirements.Unsupported,
-                diagFilePath: loc.SourceTree?.FilePath,
-                diagSpan: loc.SourceSpan,
-                diagLineSpan: loc.GetLineSpan().Span);
+                unsupportedMemberName: requirements.Unsupported);
         }
 
         private static IEnumerable<IParameterSymbol> ForwardedParameters(IMethodSymbol method)

--- a/src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs
+++ b/src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs
@@ -77,87 +77,103 @@ namespace NTypeForge.SourceGenerator
             new ProxyEmitter(possibleMatches, interfaceInfo).Emit(context, allExtensions);
         }
 
-        // Sort one candidate into the emit set (structural self-match), a diagnostic (an
-        // unmatched Duck<T> or an unsupported member), or silent drop (an unmatched implicit
-        // method-argument duck, where the original call error already stands).
+        // Sort one candidate into the emit set (every ducked argument structurally self-matches),
+        // a diagnostic (an unmatched Duck<T> or an unsupported member), or silent drop (an
+        // implicit method-argument duck with an unmatched argument, where the original call error
+        // already stands). The site is bridged or dropped as a whole: a forwarding method that
+        // ducks only some of its failing arguments could never bind.
         private static void ProcessCandidate(
             SourceProductionContext context, CandidateModel candidate,
             List<CandidateModel> allExtensions,
             Dictionary<string, InterfaceInfo> interfaceInfo,
             Dictionary<string, ConcreteInfo> concreteInfo)
         {
-            if (candidate.UnsupportedMemberName != null)
+            if (candidate.DuckedArgs.Any(a => a.UnsupportedMemberName != null))
             {
                 ReportUnsupported(context, candidate);
                 return;
             }
 
-            if (!candidate.IsSelfMatch)
+            if (candidate.DuckedArgs.Any(a => !a.IsSelfMatch))
             {
                 if (candidate.IsDuckCall)
                 {
+                    var arg = candidate.DuckedArgs[0];
                     context.ReportDiagnostic(Diagnostic.Create(
                         NoStructuralMatch, candidate.ToLocation(),
-                        candidate.UnderlyingFq, candidate.InterfaceFq));
+                        arg.UnderlyingFq, arg.InterfaceFq));
                 }
                 return;
             }
 
             allExtensions.Add(candidate);
-            RegisterInterface(interfaceInfo, candidate);
-            RegisterConcrete(concreteInfo, candidate);
+            foreach (var arg in candidate.DuckedArgs)
+            {
+                RegisterInterface(interfaceInfo, arg);
+                RegisterConcrete(concreteInfo, arg);
+            }
         }
 
         // An interface member NTypeForge can't proxy was found. An explicit Duck<T> is always a hard
         // NTF002 error. An implicit method-argument duck only earns a warning, and only at a
-        // high-confidence site whose argument already satisfies every proxyable member (IsSelfMatch
-        // over a non-empty instance contract). Ambiguous sites never reach here: CandidateAnalyzer
-        // drops a failed call with more than one duckable interpretation, so any model built for an
+        // high-confidence site where every ducked argument satisfies every proxyable member of its
+        // interface (IsSelfMatch across the whole site) - so the unsupported member really is the
+        // only blocker. The warning names each argument whose interface carries one, over a
+        // non-empty instance contract. Ambiguous sites never reach here: CandidateAnalyzer drops a
+        // failed call with more than one duckable interpretation, so any model built for an
         // implicit duck is already the unique interpretation of its call.
         private static void ReportUnsupported(SourceProductionContext context, CandidateModel candidate)
         {
             if (candidate.IsDuckCall)
             {
+                var arg = candidate.DuckedArgs[0];
                 context.ReportDiagnostic(Diagnostic.Create(
                     UnsupportedInterfaceMember, candidate.ToLocation(),
-                    candidate.InterfaceFq, candidate.UnsupportedMemberName));
+                    arg.InterfaceFq, arg.UnsupportedMemberName));
+                return;
             }
-            else if (candidate.IsSelfMatch && HasInstanceRequirements(candidate))
+
+            if (candidate.DuckedArgs.Any(a => !a.IsSelfMatch)) return;
+
+            foreach (var arg in candidate.DuckedArgs)
             {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    UnbridgeableImplicitDuck, candidate.ToLocation(),
-                    candidate.UnderlyingFq, candidate.InterfaceFq, candidate.UnsupportedMemberName));
+                if (arg.UnsupportedMemberName != null && HasInstanceRequirements(arg))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        UnbridgeableImplicitDuck, candidate.ToLocation(),
+                        arg.UnderlyingFq, arg.InterfaceFq, arg.UnsupportedMemberName));
+                }
             }
         }
 
-        private static bool HasInstanceRequirements(CandidateModel candidate)
-            => candidate.MethodRequirements.Count > 0 || candidate.PropertyRequirements.Count > 0 ||
-               candidate.IndexerRequirements.Count > 0 || candidate.EventRequirements.Count > 0;
+        private static bool HasInstanceRequirements(DuckedArgModel arg)
+            => arg.MethodRequirements.Count > 0 || arg.PropertyRequirements.Count > 0 ||
+               arg.IndexerRequirements.Count > 0 || arg.EventRequirements.Count > 0;
 
-        private static void RegisterInterface(Dictionary<string, InterfaceInfo> interfaceInfo, CandidateModel candidate)
+        private static void RegisterInterface(Dictionary<string, InterfaceInfo> interfaceInfo, DuckedArgModel arg)
         {
-            if (interfaceInfo.ContainsKey(candidate.InterfaceFq)) return;
-            interfaceInfo[candidate.InterfaceFq] = new InterfaceInfo
+            if (interfaceInfo.ContainsKey(arg.InterfaceFq)) return;
+            interfaceInfo[arg.InterfaceFq] = new InterfaceInfo
             {
-                Fq = candidate.InterfaceFq,
-                MinimalName = candidate.InterfaceMinimalName,
-                MethodRequirements = candidate.MethodRequirements,
-                PropertyRequirements = candidate.PropertyRequirements,
-                IndexerRequirements = candidate.IndexerRequirements,
-                EventRequirements = candidate.EventRequirements,
+                Fq = arg.InterfaceFq,
+                MinimalName = arg.InterfaceMinimalName,
+                MethodRequirements = arg.MethodRequirements,
+                PropertyRequirements = arg.PropertyRequirements,
+                IndexerRequirements = arg.IndexerRequirements,
+                EventRequirements = arg.EventRequirements,
             };
         }
 
-        private static void RegisterConcrete(Dictionary<string, ConcreteInfo> concreteInfo, CandidateModel candidate)
+        private static void RegisterConcrete(Dictionary<string, ConcreteInfo> concreteInfo, DuckedArgModel arg)
         {
-            if (candidate.UnderlyingIsInterface || concreteInfo.ContainsKey(candidate.UnderlyingFq)) return;
-            concreteInfo[candidate.UnderlyingFq] = new ConcreteInfo
+            if (arg.UnderlyingIsInterface || concreteInfo.ContainsKey(arg.UnderlyingFq)) return;
+            concreteInfo[arg.UnderlyingFq] = new ConcreteInfo
             {
-                Fq = candidate.UnderlyingFq,
-                Namespace = candidate.UnderlyingNamespace,
-                MinimalName = candidate.UnderlyingMinimalName,
-                BaseDepth = candidate.UnderlyingBaseDepth,
-                SurfaceKeys = new HashSet<string>(candidate.UnderlyingSurfaceCompatKeys, StringComparer.Ordinal),
+                Fq = arg.UnderlyingFq,
+                Namespace = arg.UnderlyingNamespace,
+                MinimalName = arg.UnderlyingMinimalName,
+                BaseDepth = arg.UnderlyingBaseDepth,
+                SurfaceKeys = new HashSet<string>(arg.UnderlyingSurfaceCompatKeys, StringComparer.Ordinal),
             };
         }
 

--- a/src/NTypeForge.SourceGenerator/Models/CandidateModel.cs
+++ b/src/NTypeForge.SourceGenerator/Models/CandidateModel.cs
@@ -20,27 +20,14 @@ namespace NTypeForge.SourceGenerator.Models
         public bool TargetIsInterface { get; }
         public bool TargetIsPublic { get; }
 
-        // Static type of the ducked argument (only meaningful for method-argument ducking).
-        public bool ArgumentIsInterface { get; }
-        public string ArgumentFq { get; }
+        // The arguments this site ducks, ordered by ArgumentIndex. A Duck<T> call has exactly
+        // one; a method-argument site has one per parameter that needs a proxy.
+        public IReadOnlyList<DuckedArgModel> DuckedArgs { get; }
 
-        // The type actually wrapped by the proxy (the concrete being ducked, or - when an
-        // existing proxy is re-ducked - the interface it currently presents).
-        public string UnderlyingFq { get; }
-        public string UnderlyingNamespace { get; }
-        public string UnderlyingMinimalName { get; }
-        public bool UnderlyingIsInterface { get; }
-        public int UnderlyingBaseDepth { get; }
-
-        // The interface the generated proxy implements.
-        public string InterfaceFq { get; }
-        public string InterfaceMinimalName { get; }
-
-        public int ArgumentIndex { get; }
         public bool IsStatic { get; }
         public bool IsDuckCall { get; }
 
-        // The original (failing) method whose duck-typed parameter we forward through a proxy.
+        // The original (failing) method whose duck-typed parameters we forward through proxies.
         // Unused for Duck<T> calls.
         public string OriginalMethodName { get; }
         public string OriginalContainingTypeFq { get; }
@@ -51,22 +38,6 @@ namespace NTypeForge.SourceGenerator.Models
         public int OriginalArity { get; }
         public IReadOnlyList<string> OriginalTypeParameters { get; }
         public IReadOnlyList<string> OriginalConstraints { get; }
-
-        // Members the proxy must implement (interface + inherited, deduped). Also used as the
-        // structural requirement when matching this interface against other concrete types.
-        public IReadOnlyList<MethodSig> MethodRequirements { get; }
-        public IReadOnlyList<PropertySig> PropertyRequirements { get; }
-        public IReadOnlyList<IndexerSig> IndexerRequirements { get; }
-        public IReadOnlyList<EventSig> EventRequirements { get; }
-
-        // CompatKeys of the underlying type's directly-declared methods, for matching it against
-        // other interfaces' requirements.
-        public IReadOnlyList<string> UnderlyingSurfaceCompatKeys { get; }
-        // True when the underlying type structurally satisfies the interface.
-        public bool IsSelfMatch { get; }
-        // Non-null when the interface has a member NTypeForge can't proxy (property/event/generic
-        // method); names the offending member for the NTF002 diagnostic.
-        public string? UnsupportedMemberName { get; }
 
         // Diagnostic location, decomposed so it stays equatable and roots nothing.
         public string? DiagFilePath { get; }
@@ -79,19 +50,11 @@ namespace NTypeForge.SourceGenerator.Models
 
         public CandidateModel(
             string targetFq, string targetNamespace, string targetMinimalName, bool targetIsInterface, bool targetIsPublic,
-            bool argumentIsInterface, string argumentFq,
-            string underlyingFq, string underlyingNamespace, string underlyingMinimalName, bool underlyingIsInterface, int underlyingBaseDepth,
-            string interfaceFq, string interfaceMinimalName,
-            int argumentIndex, bool isStatic, bool isDuckCall,
+            IReadOnlyList<DuckedArgModel> duckedArgs,
+            bool isStatic, bool isDuckCall,
             string originalMethodName, string originalContainingTypeFq, bool originalIsExtensionMethod,
             string originalReturnTypeFq, bool originalReturnsVoid, IReadOnlyList<ParamSig> originalParameters,
             int originalArity, IReadOnlyList<string> originalTypeParameters, IReadOnlyList<string> originalConstraints,
-            IReadOnlyList<MethodSig> methodRequirements,
-            IReadOnlyList<PropertySig> propertyRequirements,
-            IReadOnlyList<IndexerSig> indexerRequirements,
-            IReadOnlyList<EventSig> eventRequirements,
-            IReadOnlyList<string> underlyingSurfaceCompatKeys,
-            bool isSelfMatch, string? unsupportedMemberName,
             string? diagFilePath, TextSpan diagSpan, LinePositionSpan diagLineSpan)
         {
             TargetFq = targetFq;
@@ -99,16 +62,7 @@ namespace NTypeForge.SourceGenerator.Models
             TargetMinimalName = targetMinimalName;
             TargetIsInterface = targetIsInterface;
             TargetIsPublic = targetIsPublic;
-            ArgumentIsInterface = argumentIsInterface;
-            ArgumentFq = argumentFq;
-            UnderlyingFq = underlyingFq;
-            UnderlyingNamespace = underlyingNamespace;
-            UnderlyingMinimalName = underlyingMinimalName;
-            UnderlyingIsInterface = underlyingIsInterface;
-            UnderlyingBaseDepth = underlyingBaseDepth;
-            InterfaceFq = interfaceFq;
-            InterfaceMinimalName = interfaceMinimalName;
-            ArgumentIndex = argumentIndex;
+            DuckedArgs = duckedArgs;
             IsStatic = isStatic;
             IsDuckCall = isDuckCall;
             OriginalMethodName = originalMethodName;
@@ -120,13 +74,6 @@ namespace NTypeForge.SourceGenerator.Models
             OriginalArity = originalArity;
             OriginalTypeParameters = originalTypeParameters;
             OriginalConstraints = originalConstraints;
-            MethodRequirements = methodRequirements;
-            PropertyRequirements = propertyRequirements;
-            IndexerRequirements = indexerRequirements;
-            EventRequirements = eventRequirements;
-            UnderlyingSurfaceCompatKeys = underlyingSurfaceCompatKeys;
-            IsSelfMatch = isSelfMatch;
-            UnsupportedMemberName = unsupportedMemberName;
             DiagFilePath = diagFilePath;
             DiagSpan = diagSpan;
             DiagLineSpan = diagLineSpan;
@@ -138,19 +85,15 @@ namespace NTypeForge.SourceGenerator.Models
             var prms = string.Join(",", OriginalParameters.Select(p => p.Key));
             var tps = string.Join(",", OriginalTypeParameters);
             var constraints = string.Join(",", OriginalConstraints);
-            var reqs = string.Join(",", MethodRequirements.Select(m => m.CompatKey));
-            var props = string.Join(",", PropertyRequirements.Select(p => p.CompatKey));
-            var idxs = string.Join(",", IndexerRequirements.Select(i => i.CompatKey));
-            var evts = string.Join(",", EventRequirements.Select(e => e.CompatKey));
-            var surface = string.Join(",", UnderlyingSurfaceCompatKeys);
+            // Arg keys are joined with a distinct separator so arg boundaries cannot blur into
+            // the field separator used inside each key.
+            var args = string.Join(";;", DuckedArgs.Select(a => a.Key));
             return string.Join("|",
-                TargetFq, TargetIsInterface, TargetIsPublic, ArgumentFq, ArgumentIsInterface,
-                UnderlyingFq, UnderlyingIsInterface, UnderlyingBaseDepth,
-                InterfaceFq, ArgumentIndex, IsStatic, IsDuckCall,
+                TargetFq, TargetIsInterface, TargetIsPublic,
+                args, IsStatic, IsDuckCall,
                 OriginalMethodName, OriginalContainingTypeFq, OriginalIsExtensionMethod,
                 OriginalReturnTypeFq, OriginalReturnsVoid, prms,
                 OriginalArity, tps, constraints,
-                reqs, props, idxs, evts, surface, IsSelfMatch, UnsupportedMemberName ?? "",
                 DiagFilePath ?? "", DiagSpan.Start, DiagSpan.Length);
         }
 

--- a/src/NTypeForge.SourceGenerator/Models/DuckedArgModel.cs
+++ b/src/NTypeForge.SourceGenerator/Models/DuckedArgModel.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NTypeForge.SourceGenerator.Models
+{
+    // One ducked argument of a candidate site, in the same primitives-only form as CandidateModel:
+    // the argument's static type, the type the proxy wraps, the interface the proxy presents, and
+    // the structural-match verdict. A Duck<T>() site always has exactly one; a method-argument site
+    // has one per parameter that needs a proxy for the forwarded call to bind.
+    internal sealed class DuckedArgModel
+    {
+        // Index into CandidateModel.OriginalParameters (receiver-adjusted for extension methods).
+        // Zero (and meaningless) for Duck<T> calls.
+        public int ArgumentIndex { get; }
+
+        // Static type of the ducked argument.
+        public bool ArgumentIsInterface { get; }
+        public string ArgumentFq { get; }
+
+        // The type actually wrapped by the proxy (the concrete being ducked, or - when an
+        // existing proxy is re-ducked - the interface it currently presents).
+        public string UnderlyingFq { get; }
+        public string UnderlyingNamespace { get; }
+        public string UnderlyingMinimalName { get; }
+        public bool UnderlyingIsInterface { get; }
+        public int UnderlyingBaseDepth { get; }
+
+        // The interface the generated proxy implements.
+        public string InterfaceFq { get; }
+        public string InterfaceMinimalName { get; }
+
+        // Members the proxy must implement (interface + inherited, deduped). Also used as the
+        // structural requirement when matching this interface against other concrete types.
+        public IReadOnlyList<MethodSig> MethodRequirements { get; }
+        public IReadOnlyList<PropertySig> PropertyRequirements { get; }
+        public IReadOnlyList<IndexerSig> IndexerRequirements { get; }
+        public IReadOnlyList<EventSig> EventRequirements { get; }
+
+        // CompatKeys of the underlying type's directly-declared methods, for matching it against
+        // other interfaces' requirements.
+        public IReadOnlyList<string> UnderlyingSurfaceCompatKeys { get; }
+        // True when the underlying type structurally satisfies the interface.
+        public bool IsSelfMatch { get; }
+        // Non-null when the interface has a member NTypeForge can't proxy (e.g. static abstract);
+        // names the offending member for the NTF002/NTF003 diagnostics.
+        public string? UnsupportedMemberName { get; }
+
+        // Canonical key folded into CandidateModel.Key. Includes every field that affects the
+        // generated output or a reported diagnostic.
+        public string Key { get; }
+
+        public DuckedArgModel(
+            int argumentIndex, bool argumentIsInterface, string argumentFq,
+            string underlyingFq, string underlyingNamespace, string underlyingMinimalName,
+            bool underlyingIsInterface, int underlyingBaseDepth,
+            string interfaceFq, string interfaceMinimalName,
+            IReadOnlyList<MethodSig> methodRequirements,
+            IReadOnlyList<PropertySig> propertyRequirements,
+            IReadOnlyList<IndexerSig> indexerRequirements,
+            IReadOnlyList<EventSig> eventRequirements,
+            IReadOnlyList<string> underlyingSurfaceCompatKeys,
+            bool isSelfMatch, string? unsupportedMemberName)
+        {
+            ArgumentIndex = argumentIndex;
+            ArgumentIsInterface = argumentIsInterface;
+            ArgumentFq = argumentFq;
+            UnderlyingFq = underlyingFq;
+            UnderlyingNamespace = underlyingNamespace;
+            UnderlyingMinimalName = underlyingMinimalName;
+            UnderlyingIsInterface = underlyingIsInterface;
+            UnderlyingBaseDepth = underlyingBaseDepth;
+            InterfaceFq = interfaceFq;
+            InterfaceMinimalName = interfaceMinimalName;
+            MethodRequirements = methodRequirements;
+            PropertyRequirements = propertyRequirements;
+            IndexerRequirements = indexerRequirements;
+            EventRequirements = eventRequirements;
+            UnderlyingSurfaceCompatKeys = underlyingSurfaceCompatKeys;
+            IsSelfMatch = isSelfMatch;
+            UnsupportedMemberName = unsupportedMemberName;
+            Key = BuildKey();
+        }
+
+        private string BuildKey()
+        {
+            var reqs = string.Join(",", MethodRequirements.Select(m => m.CompatKey));
+            var props = string.Join(",", PropertyRequirements.Select(p => p.CompatKey));
+            var idxs = string.Join(",", IndexerRequirements.Select(i => i.CompatKey));
+            var evts = string.Join(",", EventRequirements.Select(e => e.CompatKey));
+            var surface = string.Join(",", UnderlyingSurfaceCompatKeys);
+            return string.Join("|",
+                ArgumentIndex, ArgumentFq, ArgumentIsInterface,
+                UnderlyingFq, UnderlyingIsInterface, UnderlyingBaseDepth,
+                InterfaceFq, reqs, props, idxs, evts, surface,
+                IsSelfMatch, UnsupportedMemberName ?? "");
+        }
+    }
+}

--- a/src/NTypeForge.SourceGenerator/ProxyEmitter.cs
+++ b/src/NTypeForge.SourceGenerator/ProxyEmitter.cs
@@ -51,9 +51,12 @@ namespace NTypeForge.SourceGenerator
 
             foreach (var item in allExtensions)
             {
-                AddProxy(item.UnderlyingFq, item.UnderlyingNamespace, item.UnderlyingMinimalName,
-                    item.InterfaceFq, item.InterfaceMinimalName,
-                    item.MethodRequirements, item.PropertyRequirements, item.IndexerRequirements, item.EventRequirements);
+                foreach (var arg in item.DuckedArgs)
+                {
+                    AddProxy(arg.UnderlyingFq, arg.UnderlyingNamespace, arg.UnderlyingMinimalName,
+                        arg.InterfaceFq, arg.InterfaceMinimalName,
+                        arg.MethodRequirements, arg.PropertyRequirements, arg.IndexerRequirements, arg.EventRequirements);
+                }
             }
             foreach (var kvp in _possibleMatches)
             {
@@ -147,15 +150,14 @@ namespace NTypeForge.SourceGenerator
         }
 
         // Stable, location-independent ordering key for a candidate's emitted contribution: the
-        // forwarded method name + parameter shape, then the interface and underlying types. Duck
-        // calls (empty method name / parameters) collapse to ordering by interface.
+        // forwarded method name + parameter shape, then each ducked argument's static, interface,
+        // and underlying types. Duck calls (empty method name / parameters) collapse to ordering
+        // by interface.
         private static string EmitOrderKey(CandidateModel c)
             => string.Join("|",
                 c.OriginalMethodName,
                 string.Join(",", c.OriginalParameters.Select(p => p.Key)),
-                c.ArgumentFq,
-                c.InterfaceFq,
-                c.UnderlyingFq);
+                string.Join(",", c.DuckedArgs.Select(a => $"{a.ArgumentFq}+{a.InterfaceFq}+{a.UnderlyingFq}")));
 
         // Emit a single Duck<T>() per target type that dispatches on typeof(T). One method per
         // interface would share the identical Duck<T>() signature (return type and generic
@@ -163,21 +165,22 @@ namespace NTypeForge.SourceGenerator
         // ducked to more than one interface.
         private void EmitDuckMethod(StringBuilder sb, List<CandidateModel> items, string receiver)
         {
-            var duckCandidates = new List<CandidateModel>();
+            // A Duck<T> site always ducks exactly one argument: the receiver.
+            var duckCandidates = new List<(CandidateModel Candidate, DuckedArgModel Arg)>();
             var seenDuckInterfaces = new HashSet<string>(StringComparer.Ordinal);
             foreach (var item in items)
             {
-                if (item.IsDuckCall && seenDuckInterfaces.Add(item.InterfaceFq))
-                    duckCandidates.Add(item);
+                if (item.IsDuckCall && seenDuckInterfaces.Add(item.DuckedArgs[0].InterfaceFq))
+                    duckCandidates.Add((item, item.DuckedArgs[0]));
             }
 
             if (duckCandidates.Count == 0) return;
 
             sb.AppendLine("            public T Duck<T>() where T : class");
             sb.AppendLine("            {");
-            foreach (var candidate in duckCandidates)
+            foreach (var (candidate, arg) in duckCandidates)
             {
-                var iface = candidate.InterfaceFq;
+                var iface = arg.InterfaceFq;
                 sb.AppendLine($"                if (typeof(T) == typeof({iface}))");
                 sb.AppendLine("                {");
                 // Unwrap check: only when target is an interface can it actually be a proxy that
@@ -189,7 +192,7 @@ namespace NTypeForge.SourceGenerator
                     foreach (var m in matches)
                     {
                         var local = $"__ntf_c{ui++}";
-                        sb.AppendLine($"                    if ({receiver}.TryUnbox<{m.Fq}>(out var {local})) return (T)(object)new {ProxyFullName(m.Namespace, m.MinimalName, m.Fq, candidate.InterfaceMinimalName, candidate.InterfaceFq)}({local});");
+                        sb.AppendLine($"                    if ({receiver}.TryUnbox<{m.Fq}>(out var {local})) return (T)(object)new {ProxyFullName(m.Namespace, m.MinimalName, m.Fq, arg.InterfaceMinimalName, arg.InterfaceFq)}({local});");
                     }
                 }
                 // Direct wrap. Unreachable for a proxy whose concrete type was ducked in this
@@ -197,7 +200,7 @@ namespace NTypeForge.SourceGenerator
                 // for a proxy whose concrete is unknown here (e.g. created in another assembly); in
                 // the latter case this double-wraps, but TryUnbox/Unbox still walk the full chain
                 // back to the original instance, so only single-level IProxy<T>.Inner is affected.
-                sb.AppendLine($"                    return (T)(object)new {ProxyFullName(candidate.UnderlyingNamespace, candidate.UnderlyingMinimalName, candidate.UnderlyingFq, candidate.InterfaceMinimalName, candidate.InterfaceFq)}(({candidate.UnderlyingFq}){receiver});");
+                sb.AppendLine($"                    return (T)(object)new {ProxyFullName(arg.UnderlyingNamespace, arg.UnderlyingMinimalName, arg.UnderlyingFq, arg.InterfaceMinimalName, arg.InterfaceFq)}(({arg.UnderlyingFq}){receiver});");
                 sb.AppendLine("                }");
             }
             sb.AppendLine("                throw new global::System.InvalidOperationException(\"NTypeForge: no proxy was generated for \" + typeof(T));");
@@ -218,26 +221,16 @@ namespace NTypeForge.SourceGenerator
         private void EmitForwardingMethod(
             StringBuilder sb, CandidateModel candidate, string targetFullName, string receiver, HashSet<string> generatedMethods)
         {
-            var argIndex = candidate.ArgumentIndex;
             var parameters = candidate.OriginalParameters;
-            var argName = SymbolNames.Escape(parameters[argIndex].Name);
+            var duckedByIndex = candidate.DuckedArgs.ToDictionary(a => a.ArgumentIndex);
             var methodName = SymbolNames.Escape(candidate.OriginalMethodName);
             var typeParams = candidate.OriginalArity > 0 ? $"<{string.Join(", ", candidate.OriginalTypeParameters)}>" : "";
 
-            // The forwarding call's argument list, with the duck-typed argument replaced by
-            // `argReplacement` and every other parameter passed through verbatim.
-            string CallArgs(string argReplacement) => string.Join(", ", parameters.Select((p, idx) =>
-                idx == argIndex ? argReplacement : $"{RefArgumentPrefix(p.RefKind)}{SymbolNames.Escape(p.Name)}"));
-
             var methodParams = string.Join(", ", parameters.Select((p, idx) =>
-                $"{ParamsPrefix(p)}{RefPrefix(p.RefKind)}{(idx == argIndex ? candidate.ArgumentFq : p.TypeFq)} {SymbolNames.Escape(p.Name)}{DefaultSuffix(p)}"));
+                $"{ParamsPrefix(p)}{RefPrefix(p.RefKind)}{(duckedByIndex.TryGetValue(idx, out var ducked) ? ducked.ArgumentFq : p.TypeFq)} {SymbolNames.Escape(p.Name)}{DefaultSuffix(p)}"));
 
             var methodSig = $"{methodName}{typeParams}({methodParams})";
             if (!generatedMethods.Add(methodSig)) return;
-
-            // Unwrap locals must not collide with this method's parameters or the receiver.
-            var taken = new HashSet<string>(parameters.Select(p => SymbolNames.Escape(p.Name)), StringComparer.Ordinal) { receiver };
-            var localPrefix = SafeLocalPrefix(taken);
 
             var isStatic = candidate.IsStatic ? "static " : "";
             sb.AppendLine($"            public {isStatic}{candidate.OriginalReturnTypeFq} {methodName}{typeParams}({methodParams})");
@@ -246,38 +239,124 @@ namespace NTypeForge.SourceGenerator
                 if (!string.IsNullOrEmpty(constraint)) sb.AppendLine($"                {constraint}");
             }
             sb.AppendLine("            {");
-
-            EmitForwardingUnwrapBranches(sb, candidate, argName, targetFullName, receiver, methodName, typeParams, CallArgs, localPrefix);
-
-            // Direct wrap fallback; see the note in EmitDuckMethod for the cross-assembly
-            // double-wrap boundary (recoverable via TryUnbox/Unbox).
-            var directProxy = ProxyFullName(candidate.UnderlyingNamespace, candidate.UnderlyingMinimalName, candidate.UnderlyingFq, candidate.InterfaceMinimalName, candidate.InterfaceFq);
-            var directCall = OriginalCall(candidate, targetFullName, receiver, methodName, typeParams, CallArgs($"new {directProxy}(({candidate.UnderlyingFq}){argName})"));
-            sb.AppendLine($"                {ReturnStatement(candidate.OriginalReturnsVoid, directCall)}");
+            if (candidate.DuckedArgs.Count == 1)
+                EmitSingleArgForwardingBody(sb, candidate, targetFullName, receiver, methodName, typeParams);
+            else
+                EmitMultiArgForwardingBody(sb, candidate, targetFullName, receiver, methodName, typeParams);
             sb.AppendLine("            }");
         }
 
+        // One ducked argument: each unwrap branch returns the forwarded call directly, with the
+        // direct wrap as the unconditional fall-through.
+        private void EmitSingleArgForwardingBody(
+            StringBuilder sb, CandidateModel candidate, string targetFullName, string receiver, string methodName, string typeParams)
+        {
+            var arg = candidate.DuckedArgs[0];
+            var parameters = candidate.OriginalParameters;
+            var argName = SymbolNames.Escape(parameters[arg.ArgumentIndex].Name);
+
+            string CallArgs(string argReplacement)
+                => ForwardedCallArgs(parameters, idx => idx == arg.ArgumentIndex ? argReplacement : null);
+
+            var localPrefix = SafeLocalPrefix("__ntf_c", TakenNames(parameters, receiver));
+            EmitForwardingUnwrapBranches(sb, candidate, arg, argName, targetFullName, receiver, methodName, typeParams, CallArgs, localPrefix);
+
+            // Direct wrap fallback; see the note in EmitDuckMethod for the cross-assembly
+            // double-wrap boundary (recoverable via TryUnbox/Unbox).
+            var directCall = OriginalCall(candidate, targetFullName, receiver, methodName, typeParams, CallArgs(DirectWrap(arg, argName)));
+            sb.AppendLine($"                {ReturnStatement(candidate.OriginalReturnsVoid, directCall)}");
+        }
+
+        // Several ducked arguments: each argument's proxy is resolved into an interface-typed
+        // local first (its unwrap branches run independently of the other arguments'), then one
+        // forwarding call passes them all. Returning from inside the unwrap branches - as the
+        // single-argument body does - would need a branch per combination of the arguments'
+        // unwrap outcomes.
+        private void EmitMultiArgForwardingBody(
+            StringBuilder sb, CandidateModel candidate, string targetFullName, string receiver, string methodName, string typeParams)
+        {
+            var parameters = candidate.OriginalParameters;
+            var taken = TakenNames(parameters, receiver);
+            var unwrapPrefix = SafeLocalPrefix("__ntf_c", taken);
+            var proxyPrefix = SafeLocalPrefix("__ntf_p", taken);
+
+            var replacements = new Dictionary<int, string>();
+            int unwrapCounter = 0, proxyCounter = 0;
+            foreach (var arg in candidate.DuckedArgs)
+            {
+                var argName = SymbolNames.Escape(parameters[arg.ArgumentIndex].Name);
+                replacements[arg.ArgumentIndex] = EmitArgProxyResolution(
+                    sb, arg, argName, unwrapPrefix, proxyPrefix, ref unwrapCounter, ref proxyCounter);
+            }
+
+            var callArgs = ForwardedCallArgs(parameters, idx => replacements.TryGetValue(idx, out var r) ? r : null);
+            var call = OriginalCall(candidate, targetFullName, receiver, methodName, typeParams, callArgs);
+            sb.AppendLine($"                {ReturnStatement(candidate.OriginalReturnsVoid, call)}");
+        }
+
+        // The expression producing one ducked argument's proxy: the direct wrap when the incoming
+        // value cannot be a proxy itself, otherwise a local assigned through TryUnbox branches
+        // (mirroring the single-argument unwrap branches). Counters are shared across the whole
+        // method body because an `out var` in an if-condition scopes to the enclosing block.
+        private string EmitArgProxyResolution(
+            StringBuilder sb, DuckedArgModel arg, string argName,
+            string unwrapPrefix, string proxyPrefix, ref int unwrapCounter, ref int proxyCounter)
+        {
+            var direct = DirectWrap(arg, argName);
+            if (!arg.ArgumentIsInterface || !_possibleMatches.TryGetValue(arg.InterfaceFq, out var matches) || matches.Count == 0)
+                return direct;
+
+            var local = $"{proxyPrefix}{proxyCounter++}";
+            sb.AppendLine($"                {arg.InterfaceFq} {local};");
+            var keyword = "if";
+            foreach (var m in matches)
+            {
+                var unwrapped = $"{unwrapPrefix}{unwrapCounter++}";
+                var proxy = ProxyFullName(m.Namespace, m.MinimalName, m.Fq, arg.InterfaceMinimalName, arg.InterfaceFq);
+                sb.AppendLine($"                {keyword} ({argName}.TryUnbox<{m.Fq}>(out var {unwrapped})) {local} = new {proxy}({unwrapped});");
+                keyword = "else if";
+            }
+            sb.AppendLine($"                else {local} = {direct};");
+            return local;
+        }
+
         private void EmitForwardingUnwrapBranches(
-            StringBuilder sb, CandidateModel candidate, string argName, string targetFullName, string receiver, string methodName, string typeParams,
+            StringBuilder sb, CandidateModel candidate, DuckedArgModel arg, string argName, string targetFullName, string receiver, string methodName, string typeParams,
             Func<string, string> callArgs, string localPrefix)
         {
             // Unwrap branches only make sense when the incoming value can actually be a proxy, i.e.
             // when its static type is an interface. For a concrete argument type they are dead
             // branches and force a needless box, so we skip straight to the direct wrap.
-            if (!candidate.ArgumentIsInterface || !_possibleMatches.TryGetValue(candidate.InterfaceFq, out var matches))
+            if (!arg.ArgumentIsInterface || !_possibleMatches.TryGetValue(arg.InterfaceFq, out var matches))
                 return;
 
             int ui = 0;
             foreach (var m in matches)
             {
                 var local = $"{localPrefix}{ui++}";
-                var proxy = ProxyFullName(m.Namespace, m.MinimalName, m.Fq, candidate.InterfaceMinimalName, candidate.InterfaceFq);
+                var proxy = ProxyFullName(m.Namespace, m.MinimalName, m.Fq, arg.InterfaceMinimalName, arg.InterfaceFq);
                 var call = OriginalCall(candidate, targetFullName, receiver, methodName, typeParams, callArgs($"new {proxy}({local})"));
                 sb.AppendLine($"                if ({argName}.TryUnbox<{m.Fq}>(out var {local})) {{");
                 sb.AppendLine($"                    {(candidate.OriginalReturnsVoid ? $"{call}; return;" : $"return {call};")}");
                 sb.AppendLine("                }");
             }
         }
+
+        // The forwarding call's argument list: each ducked index replaced per `replacementFor`
+        // (null = not ducked), every other parameter passed through verbatim.
+        private static string ForwardedCallArgs(IReadOnlyList<ParamSig> parameters, Func<int, string?> replacementFor)
+            => string.Join(", ", parameters.Select((p, idx) =>
+                replacementFor(idx) ?? $"{RefArgumentPrefix(p.RefKind)}{SymbolNames.Escape(p.Name)}"));
+
+        // The unconditional wrap of a ducked argument in its proxy; see the note in EmitDuckMethod
+        // for the cross-assembly double-wrap boundary (recoverable via TryUnbox/Unbox).
+        private static string DirectWrap(DuckedArgModel arg, string argName)
+            => $"new {ProxyFullName(arg.UnderlyingNamespace, arg.UnderlyingMinimalName, arg.UnderlyingFq, arg.InterfaceMinimalName, arg.InterfaceFq)}(({arg.UnderlyingFq}){argName})";
+
+        // Names a generated local must not collide with: the forwarding method's parameters and
+        // the extension receiver.
+        private static HashSet<string> TakenNames(IReadOnlyList<ParamSig> parameters, string receiver)
+            => new HashSet<string>(parameters.Select(p => SymbolNames.Escape(p.Name)), StringComparer.Ordinal) { receiver };
 
         private static string OriginalCall(
             CandidateModel candidate, string targetFullName, string receiver, string methodName, string typeParams, string args)
@@ -430,11 +509,11 @@ namespace NTypeForge.SourceGenerator
         }
 
         // A prefix for generated locals emitted as `{prefix}0`, `{prefix}1`, ... that no name in
-        // `taken` collides with. The `__ntf_c` base is already collision-resistant; the loop makes
-        // it bulletproof.
-        private static string SafeLocalPrefix(ICollection<string> taken)
+        // `taken` collides with. The `__ntf_*` bases are already collision-resistant; the loop
+        // makes them bulletproof.
+        private static string SafeLocalPrefix(string basePrefix, ICollection<string> taken)
         {
-            var prefix = "__ntf_c";
+            var prefix = basePrefix;
             while (taken.Any(n => n.StartsWith(prefix, StringComparison.Ordinal) && n.Length > prefix.Length && char.IsDigit(n[prefix.Length])))
                 prefix = "_" + prefix;
             return prefix;

--- a/tests/NTypeForge.Generator.Tests/CodegenValidityTests.cs
+++ b/tests/NTypeForge.Generator.Tests/CodegenValidityTests.cs
@@ -103,6 +103,108 @@ public class CodegenValidityTests
         Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
     }
 
+    // Issue #11: a call can need several arguments ducked at once. One forwarding extension must
+    // replace every duck-typed parameter, wrapping each argument in its own proxy - the user's
+    // call cannot bind otherwise. (If nothing were generated, the snippet's own call error would
+    // surface here, so this assertion is not vacuous.)
+    [Fact]
+    public void TwoDuckedArguments_EmitCompilableCode()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public interface ILog { string Log(string m); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Logger { public string Log(string m) => m; }
+                public class Mgr
+                {
+                    public string H(ICalc c, ILog l, int offset) => l.Log((c.Add(1, 2) + offset).ToString());
+                    public void M() { var m = new Mgr(); m.H(new Adder(), new Logger(), 3); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    // Two ducked arguments of the *same* interface: one proxy type, two independent wraps.
+    [Fact]
+    public void TwoDuckedArguments_SameInterface_EmitCompilableCode()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Mgr
+                {
+                    public int H(ICalc first, ICalc second) => first.Add(1, 2) + second.Add(3, 4);
+                    public void M() { var m = new Mgr(); m.H(new Adder(), new Adder()); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    // Three ducked arguments interleaved with passthrough parameters, supplied via named,
+    // reordered arguments: parameter mapping and per-argument replacement must agree.
+    [Fact]
+    public void ThreeDuckedArguments_WithNamedReorderedArguments_EmitCompilableCode()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public interface ILog { string Log(string m); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Logger { public string Log(string m) => m; }
+                public class Mgr
+                {
+                    public string H(ICalc c, int offset, ILog l, ILog l2) => l2.Log(l.Log((c.Add(1, 2) + offset).ToString()));
+                    public void M() { var m = new Mgr(); m.H(l: new Logger(), c: new Adder(), offset: 3, l2: new Logger()); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    // One of the two ducked arguments is itself interface-typed (a re-ducked proxy): its proxy is
+    // resolved through TryUnbox branches into a local, alongside the direct wrap of the concrete
+    // argument - the multi-argument body shape.
+    [Fact]
+    public void TwoDuckedArguments_OneInterfaceTyped_EmitCompilableCode()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public interface IOther { int Add(int a, int b); }
+                public interface ILog { string Log(string m); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Logger { public string Log(string m) => m; }
+                public class Mgr
+                {
+                    public string H(ICalc c, ILog l) => l.Log(c.Add(1, 2).ToString());
+                    public void M()
+                    {
+                        var m = new Mgr();
+                        IOther other = new Adder().Duck<IOther>();
+                        m.H(other, new Logger());
+                    }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
     [Fact]
     public void MethodArgumentDucking_ForExtensionMethod_EmitsCompilableCode()
     {

--- a/tests/NTypeForge.Generator.Tests/DiagnosticTests.cs
+++ b/tests/NTypeForge.Generator.Tests/DiagnosticTests.cs
@@ -413,6 +413,83 @@ public class DiagnosticTests
         Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
     }
 
+    // Several arguments duck in the same call only as a whole: when one of them has no structural
+    // match, the site must not be bridged at all (a forwarding method ducking just the matching
+    // argument could never bind), and no NTF00x may mask the compiler's own error.
+    [Fact]
+    public void TwoDuckableArguments_OneWithoutMatch_IsNotRewired()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public interface ILog { string Log(string m); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class NotALogger { public int Other() => 0; }
+                public class Mgr
+                {
+                    public string H(ICalc c, ILog l) => l.Log(c.Add(1, 2).ToString());
+                    public void M() { var m = new Mgr(); m.H(new Adder(), new NotALogger()); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
+        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
+    }
+
+    // The multi-argument near-miss: every ducked argument satisfies its proxyable contract and the
+    // only blocker is one interface's unsupported (static-abstract) member - exactly one NTF003,
+    // naming that argument.
+    [Fact]
+    public void NTF003_WhenOneOfTwoDuckedArgumentsBlockedOnlyByUnsupportedMember()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public interface IFactory { static abstract IFactory Create(); int Do(); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Impl { public int Do() => 1; }
+                public class Mgr
+                {
+                    public void H(ICalc c, IFactory f) {}
+                    public void M() { var m = new Mgr(); m.H(new Adder(), new Impl()); }
+                }
+            }
+            """;
+
+        var diagnostics = GeneratorTestHarness.GetGeneratorDiagnostics(source);
+        var ntf003 = diagnostics.Single(d => d.Id == "NTF003");
+        Assert.Contains("IFactory", ntf003.GetMessage());
+    }
+
+    // Two overloads, each of which could fix the call by ducking both of its arguments, are still
+    // ambiguous: multi-argument support must not erode the one-interpretation rule.
+    [Fact]
+    public void AmbiguousOverloads_WithTwoDuckableArgumentsEach_AreNotRewired()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface IA { int Do(); }
+                public interface IB { int Do(); }
+                public class Impl { public int Do() => 1; }
+                public class Mgr
+                {
+                    public void H(IA a, IB b) {}
+                    public void H(IB a, IA b) {}
+                    public void M() { var m = new Mgr(); m.H(new Impl(), new Impl()); }
+                }
+            }
+            """;
+
+        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
+    }
+
     // A static-qualified `DuckExtensions.Duck<T>(x)` cannot bind to the generated instance extension
     // member, so it is not a duck site. The analyzer must not mistake the `DuckExtensions` type for
     // the ducked instance and report a spurious NTF001 against it.

--- a/tests/NTypeForge.Tests/MultipleArgumentDuckingTests.cs
+++ b/tests/NTypeForge.Tests/MultipleArgumentDuckingTests.cs
@@ -1,0 +1,88 @@
+using Xunit;
+
+namespace NTypeForge.Tests;
+
+// Issue #11: several arguments of one call can need ducking at the same time. The generator
+// emits a single forwarding extension that replaces every duck-typed parameter and wraps each
+// argument in its own proxy - ducking one argument per call could never make such a call bind.
+
+public interface ISummer { int Sum(int a, int b); }
+public interface IStamper { string Stamp(string text); }
+
+// Structurally identical to ISummer; used to hand an already-proxied value into a call that
+// needs it re-ducked to ISummer.
+public interface IOtherSummer { int Sum(int a, int b); }
+
+public class PlainSummer { public int Sum(int a, int b) => a + b; }
+public class PlainStamper { public string Stamp(string text) => $"[{text}]"; }
+
+public class Pipeline
+{
+    public string Run(ISummer summer, IStamper stamper, int x, int y)
+        => stamper.Stamp(summer.Sum(x, y).ToString());
+
+    public static string RunStatic(ISummer summer, IStamper stamper)
+        => stamper.Stamp(summer.Sum(1, 2).ToString());
+
+    public int RunPair(ISummer first, ISummer second)
+        => first.Sum(1, 2) + second.Sum(3, 4);
+
+    public string RunThree(ISummer summer, string sep, IStamper stamper, IStamper again)
+        => again.Stamp(stamper.Stamp(summer.Sum(2, 3).ToString()) + sep);
+}
+
+public class MultipleArgumentDuckingTests
+{
+    [Fact]
+    public void DucksTwoArgumentsInOneCall()
+    {
+        var result = new Pipeline().Run(new PlainSummer(), new PlainStamper(), 10, 20);
+
+        Assert.Equal("[30]", result);
+    }
+
+    [Fact]
+    public void DucksTwoArgumentsInStaticCall()
+    {
+        var result = Pipeline.RunStatic(new PlainSummer(), new PlainStamper());
+
+        Assert.Equal("[3]", result);
+    }
+
+    [Fact]
+    public void DucksTwoArgumentsOfSameInterface()
+    {
+        var result = new Pipeline().RunPair(new PlainSummer(), new PlainSummer());
+
+        Assert.Equal(10, result);
+    }
+
+    [Fact]
+    public void DucksThreeArgumentsAroundPassthroughParameter()
+    {
+        var result = new Pipeline().RunThree(new PlainSummer(), "!", new PlainStamper(), new PlainStamper());
+
+        Assert.Equal("[[5]!]", result);
+    }
+
+    [Fact]
+    public void DucksTwoArgumentsWithNamedReorderedArguments()
+    {
+        var result = new Pipeline().Run(stamper: new PlainStamper(), summer: new PlainSummer(), x: 1, y: 2);
+
+        Assert.Equal("[3]", result);
+    }
+
+    [Fact]
+    public void DucksProxyArgumentAlongsideConcreteArgument()
+    {
+        // `viaOther` is a proxy with static type IOtherSummer; passing it where ISummer is
+        // expected re-ducks it (unwrapping back to the PlainSummer rather than stacking proxies),
+        // while the PlainStamper in the same call gets its own direct proxy.
+        IOtherSummer viaOther = new PlainSummer().Duck<IOtherSummer>();
+
+        var result = new Pipeline().Run(viaOther, new PlainStamper(), 4, 5);
+
+        Assert.Equal("[9]", result);
+    }
+}


### PR DESCRIPTION
## Summary

This PR extends NTypeForge to support duck-typing multiple arguments in a single method call. Previously, only single-argument duck-typing was supported. Now, when a call fails to bind due to multiple parameters expecting interfaces, the generator can create a single forwarding method that wraps each failing argument in its own proxy.

## Key Changes

- **New `DuckedArgModel` class**: Extracted per-argument duck-typing information into a dedicated model that holds the argument's static type, underlying type, interface type, and structural match information. This replaces the flat fields that were previously on `CandidateModel`.

- **Updated `CandidateModel`**: Replaced individual `ArgumentFq`, `UnderlyingFq`, `InterfaceFq`, and related fields with a `DuckedArgs` collection of `DuckedArgModel` instances. A Duck<T>() call has exactly one; a method-argument site has one per parameter needing a proxy.

- **Enhanced `CandidateAnalyzer`**:
  - Added `DuckedArgSite` struct to track ducked arguments during analysis
  - Modified `CollectDuckableInterpretations` to group all duckable arguments of each overload together as a single interpretation
  - Added `ResolveDuckedArgSites` to validate all arguments of a chosen overload and resolve them to their symbol triples
  - Updated ambiguity detection: multiple interpretations (different overloads) are still rejected, but all arguments within one overload are ducked together

- **Updated `ProxyEmitter`**:
  - Modified `EmitForwardingMethod` to handle multiple ducked arguments with separate unwrap/wrap logic per argument
  - Split forwarding body emission into `EmitSingleArgForwardingBody` and `EmitMultiArgForwardingBody` for clarity
  - Updated `EmitDuckMethod` to work with the new `DuckedArgs` collection
  - Updated `EmitOrderKey` to include all ducked arguments in the ordering key

- **Updated `DuckTypingGenerator`**: Modified diagnostic reporting to iterate over all ducked arguments when checking for unsupported members or structural matches.

## Notable Implementation Details

- **All-or-nothing semantics**: A forwarding method must replace every duck-typed parameter for the call to bind. If any argument lacks a structural match, the entire site is left alone and the original compiler error surfaces.

- **Ambiguity preservation**: The one-interpretation rule is maintained—multiple overloads that could each fix the call by ducking their arguments are still rejected as ambiguous.

- **Named/reordered argument support**: Arguments are sorted by emitted parameter index so the model is independent of call-site argument order.

- **Re-ducking support**: When an interface-typed argument (an existing proxy) is passed where a different interface is expected, it's unwrapped via `TryUnbox` branches alongside direct wraps of concrete arguments.

## Tests Added

- `TwoDuckedArguments_EmitCompilableCode`: Basic two-argument ducking
- `TwoDuckedArguments_SameInterface_EmitCompilableCode`: Two arguments of the same interface
- `ThreeDuckedArguments_WithNamedReorderedArguments_EmitCompilableCode`: Three arguments with named/reordered calls
- `TwoDuckedArguments_OneInterfaceTyped_EmitCompilableCode`: Re-ducking a proxy alongside a concrete argument
- `MultipleArgumentDuckingTests`: Runtime tests covering various multi-argument scenarios
- Diagnostic tests ensuring ambiguous overloads and partial matches are handled correctly

https://claude.ai/code/session_01RmbcNFikNmJjVei2eifU7U