### PR TITLE
Avoid ducking by-ref interface arguments

### DIFF
--- a/src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs
+++ b/src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs
@@ -358,7 +358,14 @@ namespace NTypeForge.SourceGenerator
         {
             if (paramIndex < 0) return false;
 
-            var paramType = candidate.Parameters[paramIndex].Type;
+            var parameter = candidate.Parameters[paramIndex];
+            // Ducking rewrites the failed call by replacing the argument expression with a freshly
+            // constructed proxy. That is only valid for by-value parameters: ref/out/in parameters
+            // require a variable passed with the corresponding modifier, and a generated proxy
+            // temporary cannot be used to preserve those semantics.
+            if (parameter.RefKind != RefKind.None) return false;
+
+            var paramType = parameter.Type;
             if (paramType == null || paramType.TypeKind != TypeKind.Interface) return false;
 
             var argFact = argFacts[syntaxIndex] ??=

--- a/tests/NTypeForge.Generator.Tests/CodegenValidityTests.cs
+++ b/tests/NTypeForge.Generator.Tests/CodegenValidityTests.cs
@@ -226,6 +226,34 @@ public class CodegenValidityTests
         Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
     }
 
+    [Theory]
+    [InlineData("ref")]
+    [InlineData("out")]
+    [InlineData("in")]
+    public void MethodArgumentDucking_ByRefInterfaceParameter_IsNotRewired(string modifier)
+    {
+        var source = $$"""
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Mgr
+                {
+                    public void H({{modifier}} ICalc c) { }
+                    public void M()
+                    {
+                        var m = new Mgr();
+                        var a = new Adder();
+                        m.H({{modifier}} a);
+                    }
+                }
+            }
+            """;
+
+        Assert.DoesNotContain("DuckTypingExtensions", GeneratorTestHarness.GetGeneratedText(source));
+    }
+
     [Fact]
     public void MethodArgumentDucking_WithMultipleGenericMethodInstantiations_EmitsCompilableCode()
     {


### PR DESCRIPTION
### Motivation

- Implicit method-argument ducking rewrites failed calls by inserting generated proxy temporaries, which cannot preserve by-reference (`ref`/`out`/`in`) semantics and would produce incorrect or uncompilable code.

### Description

- Stop treating a parameter as duckable when its `RefKind` is not `None` by adding an early `return false` in `IsDuckableArgument` in `src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs`.
- Add a regression `Theory` in `tests/NTypeForge.Generator.Tests/CodegenValidityTests.cs` named `MethodArgumentDucking_ByRefInterfaceParameter_IsNotRewired` with `InlineData("ref")`, `InlineData("out")`, and `InlineData("in")` to assert the generator does not emit `DuckTypingExtensions` for by-ref interface parameters.

### Testing

- Attempted to run unit tests with `dotnet test --no-restore`, but the command could not be executed because `dotnet` is not installed in the environment, so the new tests were not run here.
- The change includes a new unit test that will run under CI / a local environment with the .NET SDK and should assert the generator does not rewrite by-ref interface arguments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3075db92a08323ae09c9aa1d0448b7)