### PR TITLE
🛡️ Sentinel: [SECURITY ENHANCEMENT] Use SHA-256 for proxy naming hash

### DIFF
--- a/src/NTypeForge.SourceGenerator/ProxyEmitter.cs
+++ b/src/NTypeForge.SourceGenerator/ProxyEmitter.cs
@@ -550,21 +550,20 @@ namespace NTypeForge.SourceGenerator
             string underlyingMinimalName, string underlyingFq, string interfaceMinimalName, string interfaceFq)
             => $"{Sanitize(underlyingMinimalName)}_{Sanitize(interfaceMinimalName)}_Proxy_{StableHash(underlyingFq + "|" + interfaceFq)}";
 
-        // A deterministic 32-bit FNV-1a hash rendered as hex. string.GetHashCode is randomized per
-        // process, which would break the generator's required determinism; this is stable across
-        // runs and platforms.
+        // A deterministic SHA-256 hash (truncated to 32 hex chars) for collision resistance.
+        // string.GetHashCode is randomized per process, which would break the generator's required
+        // determinism; this is stable across runs and platforms.
         private static string StableHash(string value)
         {
-            unchecked
+            using var sha = global::System.Security.Cryptography.SHA256.Create();
+            var bytes = global::System.Text.Encoding.UTF8.GetBytes(value);
+            var hash = sha.ComputeHash(bytes);
+            var sb = new StringBuilder(32);
+            for (int i = 0; i < 16; i++)
             {
-                uint hash = 2166136261;
-                foreach (var c in value)
-                {
-                    hash ^= c;
-                    hash *= 16777619;
-                }
-                return hash.ToString("x8");
+                sb.Append(hash[i].ToString("x2"));
             }
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [SECURITY ENHANCEMENT] Use SHA-256 for proxy naming hash

**Severity:** MEDIUM (Defense in depth / SAST false positive reduction)
**Vulnerability:** The source generator used an FNV-1a hash algorithm to generate a deterministic hash suffix for proxy classes and generated source files. FNV-1a is a non-cryptographic hash function with a higher risk of hash collisions and is often flagged by static application security testing (SAST) tools as a security weakness.
**Impact:** While unlikely to be exploitable as a traditional vulnerability (as it runs at compile-time and attackers controlling source code already have execution), hash collisions in generated proxies could lead to naming conflicts (CS0101) or subtly wrong types being referenced during compilation. Using a weak hash violates defense in depth principles.
**Fix:** Replaced the FNV-1a algorithm with a truncated SHA-256 implementation from `System.Security.Cryptography.SHA256`. This ensures cryptographic collision resistance while maintaining the deterministic properties required by the incremental source generator.
**Verification:** Verified by running the generator unit tests `dotnet test tests/NTypeForge.Generator.Tests/NTypeForge.Generator.Tests.csproj`. All 97 tests passed successfully.

---
*PR created automatically by Jules for task [9196907973423408160](https://jules.google.com/task/9196907973423408160) started by @timonkrebs*