### PR TITLE
Ship NTypeForge as a consumable NuGet package + CI pack smoke-test

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,3 +44,37 @@ jobs:
         dotnet-version: 10.0.x
     - name: Cognitive Complexity gate (S3776 <= 15)
       run: dotnet build -p:MeasureCognitiveComplexity=true -p:WarningsAsErrors=S3776
+
+  pack:
+    # Smoke-test the NuGet package: pack the runtime project (which also packs the generator into
+    # analyzers/dotnet/cs) and assert the produced .nupkg actually contains both the runtime
+    # assembly and the generator in the analyzer path - the layout a consuming project needs. This
+    # catches a broken analyzer-packing setup here, before a release ships it.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+    - name: Pack
+      run: dotnet pack src/NTypeForge/NTypeForge.csproj -c Release -o ${{ runner.temp }}/artifacts
+    - name: Verify package layout
+      shell: bash
+      run: |
+        pkg=$(ls ${{ runner.temp }}/artifacts/NTypeForge.*.nupkg | head -1)
+        echo "Inspecting $pkg"
+        contents=$(unzip -Z1 "$pkg")
+        echo "$contents"
+        check() { echo "$contents" | grep -qx "$1" || { echo "::error::missing from package: $1"; exit 1; }; }
+        check 'lib/net10.0/NTypeForge.dll'
+        check 'analyzers/dotnet/cs/NTypeForge.SourceGenerator.dll'
+        check 'README.md'
+        echo 'Package layout OK.'
+    - name: Upload package
+      uses: actions/upload-artifact@v4
+      with:
+        name: nupkg
+        path: ${{ runner.temp }}/artifacts/*nupkg

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Minimal GITHUB_TOKEN scope for the whole workflow: every job only checks out the repo and
+# builds/tests/packs, so read-only access to contents is all the token needs (CodeQL hardening).
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,25 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <!--
+    Shared NuGet package metadata. Inert for every project except the runtime NTypeForge project,
+    which is the single shipping package (it sets IsPackable=true plus the package identity). The
+    default IsPackable=false here keeps the test/benchmark/generator projects from ever packing.
+  -->
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <Authors>Timon Krebs</Authors>
+    <Company>Timon Krebs</Company>
+    <Product>NTypeForge</Product>
+    <Copyright>Copyright © 2026 Timon Krebs</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/timonkrebs/NTypeForge</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/timonkrebs/NTypeForge</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageTags>duck-typing;structural-typing;source-generator;roslyn;codegen;proxy</PackageTags>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(MeasureCognitiveComplexity)' == 'true'">
     <!-- Pinned, not `*`: a floating analyzer version can change S3776 scoring and break CI with no
          code change. Bump deliberately. -->

--- a/README.md
+++ b/README.md
@@ -103,9 +103,22 @@ In every project that *consumes* NTypeForge, set the language version to preview
 
 ## Installation
 
-NTypeForge is not published to NuGet yet. Reference both projects directly. Note
-the **two** references: the runtime library plus the source generator wired in as an
-analyzer.
+NTypeForge ships as a **single NuGet package** that bundles the runtime library and the
+source generator (wired in as an analyzer) together, so consuming it is one reference.
+
+> **Not on nuget.org yet.** The package is built and smoke-tested in CI but isn't pushed
+> to a public feed. Until it is, consume it from source with the project references below.
+
+Once published, a single package reference pulls in both the runtime and the generator:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="NTypeForge" Version="0.1.0-preview.1" />
+</ItemGroup>
+```
+
+To consume **from source** (the current path), reference **both** projects — the runtime
+library plus the source generator wired in as an analyzer:
 
 ```xml
 <ItemGroup>

--- a/src/NTypeForge.SourceGenerator/AnalyzerReleases.Shipped.md
+++ b/src/NTypeForge.SourceGenerator/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/NTypeForge.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/NTypeForge.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,10 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+NTF001 | NTypeForge | Error | No structural match for Duck<T>.
+NTF002 | NTypeForge | Error | Unsupported interface member for duck typing.
+NTF003 | NTypeForge | Warning | Type structurally matches but cannot be implicitly duck-typed.

--- a/src/NTypeForge.SourceGenerator/NTypeForge.SourceGenerator.csproj
+++ b/src/NTypeForge.SourceGenerator/NTypeForge.SourceGenerator.csproj
@@ -8,9 +8,17 @@
     <IsRoslynComponent>true</IsRoslynComponent>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
-    <!-- RS2008: analyzer release tracking is for shipped analyzer packages; not applicable here. -->
-    <NoWarn>$(NoWarn);RS2008</NoWarn>
   </PropertyGroup>
+
+  <!--
+    Analyzer release tracking for the shipped diagnostics (NTF001-003). The two AnalyzerReleases
+    files pin each diagnostic's ID, category, and severity across package versions; their presence
+    satisfies RS2008, so it no longer needs suppressing.
+  -->
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">

--- a/src/NTypeForge/NTypeForge.csproj
+++ b/src/NTypeForge/NTypeForge.csproj
@@ -1,9 +1,56 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <!--
+    NTypeForge ships as a single NuGet package: the net10.0 runtime types (IProxy, DuckExtensions)
+    in lib/, plus the source generator packed into analyzers/dotnet/cs (see the generator
+    ProjectReference and the _PackNTypeForgeGenerator target below). A consumer references this one
+    package and gets both the runtime surface and the compile-time generator.
+  -->
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <PackageId>NTypeForge</PackageId>
+    <Version>0.1.0-preview.1</Version>
+    <Description>Structural (duck) typing for C#, generated at compile time. A Roslyn incremental source generator spots calls that pass a structurally-matching type where an interface is expected, generates a tiny proxy, and rewires the call - no reflection, no hand-written adapters. Experimental: relies on C# 14 preview extension members.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The README rendered on the package page. -->
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <!--
+    Build the generator and capture its output DLL without taking a compile-time reference or
+    emitting a NuGet dependency on it (ReferenceOutputAssembly=false + PrivateAssets=all). The
+    custom OutputItemType lands the built path in @(_NTypeForgeGenerator) for the pack target.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\NTypeForge.SourceGenerator\NTypeForge.SourceGenerator.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="_NTypeForgeGenerator"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_PackNTypeForgeGenerator</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <!-- Place the generator where Roslyn discovers analyzers in a consuming project. -->
+  <Target Name="_PackNTypeForgeGenerator" DependsOnTargets="ResolveProjectReferences">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(_NTypeForgeGenerator)">
+        <PackagePath>analyzers/dotnet/cs</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
## What

Makes NTypeForge installable as a NuGet package and adds a CI smoke-test that verifies the package is laid out correctly. Previously the project had **no packaging at all**, and — critically — the generator DLL wasn't packed into `analyzers/dotnet/cs`, so even with a `PackageId` set it could never have been consumed.

## Changes

**Packaging** (`a6ca365`)
- The runtime **`NTypeForge`** project is now the single shipping package: runtime types (`IProxy`, `DuckExtensions`) in `lib/net10.0`, and the source generator packed into `analyzers/dotnet/cs` so Roslyn discovers and loads it in consuming projects.
- The generator is captured from a `ProjectReference` with `ReferenceOutputAssembly=false` + `PrivateAssets=all` (no compile-time reference, no leaked NuGet dependency) and emitted via a `TfmSpecificPackageFile` target.
- Package metadata: `PackageId`, version `0.1.0-preview.1`, description, README, symbols (`snupkg`), XML docs. Shared metadata (authors, **Apache-2.0** license, repo URL, tags) lives in `Directory.Build.props` with a default `IsPackable=false`, so only the runtime project packs.
- Analyzer release tracking (`AnalyzerReleases.Shipped/Unshipped.md`) for the `NTF001–003` diagnostics so their IDs/severities stay stable across versions — this replaces the `RS2008` suppression.

**CI** (`5592b89`)
- New `pack` job runs `dotnet pack` and asserts the produced `.nupkg` contains `lib/net10.0/NTypeForge.dll` **and** `analyzers/dotnet/cs/NTypeForge.SourceGenerator.dll`, then uploads the package as an artifact. This fails loudly if the analyzer-packing ever breaks.

## Notes
- The dev environment has **no .NET SDK**, so this couldn't be packed locally — **this PR's `pack` job is the verification**. The two things most likely to need a CI round-trip are the `AnalyzerReleases` format and the pack target's MSBuild plumbing.
- Version `0.1.0-preview.1` and author `Timon Krebs` are sensible defaults — adjust to taste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7W1dyFLg9YmH8GpCiG7Cs

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7W1dyFLg9YmH8GpCiG7Cs)_