### PR TITLE
Tier 2 CI hardening: coverage, NuGet caching, Dependabot for Actions, release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Workflows under .github/workflows
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -41,6 +41,7 @@ jobs:
       # Informational: never fail the job over coverage tooling. Surfaces the % in the run summary
       # and uploads a full report artifact; the test run above already gathered the data.
       if: always()
+      continue-on-error: true
       shell: bash
       run: |
         files=$(find "${{ runner.temp }}/coverage" -name 'coverage.cobertura.xml' 2>/dev/null || true)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,12 +25,37 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+        restore-keys: ${{ runner.os }}-nuget-
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ${{ runner.temp }}/coverage
+    - name: Coverage summary
+      # Informational: never fail the job over coverage tooling. Surfaces the % in the run summary
+      # and uploads a full report artifact; the test run above already gathered the data.
+      if: always()
+      shell: bash
+      run: |
+        files=$(find "${{ runner.temp }}/coverage" -name 'coverage.cobertura.xml' 2>/dev/null || true)
+        [ -z "$files" ] && { echo "No coverage files found; skipping."; exit 0; }
+        export PATH="$PATH:$HOME/.dotnet/tools"
+        dotnet tool install --global dotnet-reportgenerator-globaltool >/dev/null
+        reportgenerator -reports:"${{ runner.temp }}/coverage/**/coverage.cobertura.xml" -targetdir:"${{ runner.temp }}/coverage/report" -reporttypes:"MarkdownSummaryGithub;Cobertura" >/dev/null
+        cat "${{ runner.temp }}/coverage/report/SummaryGithub.md" >> "$GITHUB_STEP_SUMMARY"
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage
+        path: ${{ runner.temp }}/coverage/report
+        if-no-files-found: ignore
 
   cognitive-complexity:
     # Gate on SonarSource Cognitive Complexity (rule S3776). The opt-in
@@ -47,6 +72,12 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+        restore-keys: ${{ runner.os }}-nuget-
     - name: Cognitive Complexity gate (S3776 <= 15)
       run: dotnet build -p:MeasureCognitiveComplexity=true -p:WarningsAsErrors=S3776
 
@@ -64,6 +95,12 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props') }}
+        restore-keys: ${{ runner.os }}-nuget-
     - name: Pack
       run: dotnet pack src/NTypeForge/NTypeForge.csproj -c Release -o ${{ runner.temp }}/artifacts
     - name: Verify package layout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+# Publish a GitHub Release from a version tag. Tag a commit on green `main` as `vX.Y.Z`
+# (e.g. `v0.1.0-preview.1`) and push the tag; this packs that version and attaches the
+# .nupkg/.snupkg to a GitHub Release. The tag (minus the leading `v`) IS the package version, so
+# it is the single source of truth - no need to bump the csproj first. A tag with a pre-release
+# suffix (a `-`, e.g. `-preview.1`) is published as a GitHub pre-release.
+on:
+  push:
+    tags: [ "v*" ]
+
+# Needs write access to create the Release; the build workflow stays read-only.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+    - name: Pack (version from tag)
+      shell: bash
+      run: |
+        version="${GITHUB_REF_NAME#v}"
+        echo "Packing version $version"
+        dotnet pack src/NTypeForge/NTypeForge.csproj -c Release -p:Version="$version" -o "${{ runner.temp }}/artifacts"
+    - name: Create GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      shell: bash
+      run: |
+        prerelease=""
+        case "$GITHUB_REF_NAME" in *-*) prerelease="--prerelease";; esac
+        gh release create "$GITHUB_REF_NAME" \
+          "${{ runner.temp }}"/artifacts/*nupkg \
+          --title "$GITHUB_REF_NAME" \
+          --generate-notes \
+          $prerelease


### PR DESCRIPTION
## What

Tier 2 CI hardening, following the packaging work in #34.

## Changes

**Code coverage** (`1c2c287`)
- The `build` job's existing test run now collects coverage (`--collect:"XPlat Code Coverage"` — `coverlet.collector` was already referenced but never actually used). A ReportGenerator summary is written into the GitHub run summary, and the full report is uploaded as an artifact. The coverage step is informational and never fails the job.

**NuGet caching** (`1c2c287`)
- All three jobs cache `~/.nuget/packages`, keyed on the project + central version files, so restores reuse downloads across runs.

**Dependabot for Actions** (`82e1428`)
- Adds the `github-actions` ecosystem so action pins (`checkout`, `setup-dotnet`, `cache`, `upload-artifact`, …) get the same weekly update PRs as NuGet packages.

**Release workflow** (`7b97792`)
- New tag-triggered `release.yml`: push a `vX.Y.Z` tag on green `main` to pack that version (the tag, minus the leading `v`, drives the package version) and publish a GitHub Release with the `.nupkg`/`.snupkg` attached. Tags with a pre-release suffix (`-preview.1`) publish as GitHub pre-releases. Uses the pre-installed `gh` CLI + `GITHUB_TOKEN` — no third-party action, no extra secrets; scoped to `contents: write`.

## Notes
- `release.yml` only triggers on tags, so it won't run in this PR — the `build` (coverage + caching), `cognitive-complexity`, and `pack` jobs verify the changes here.
- No nuget.org publishing (per your call) — releases attach the package to a GitHub Release only. Switching to a feed later is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7W1dyFLg9YmH8GpCiG7Cs

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7W1dyFLg9YmH8GpCiG7Cs)_