### PR TITLE
Add a runnable NTypeForge.Sample, plus a three-distinct-interface ducking test

### DIFF
--- a/NTypeForge.slnx
+++ b/NTypeForge.slnx
@@ -15,4 +15,7 @@
   <Folder Name="/bench/">
     <Project Path="bench/NTypeForge.Benchmarks/NTypeForge.Benchmarks.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/NTypeForge.Sample/NTypeForge.Sample.csproj" />
+  </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ library plus the source generator wired in as an analyzer:
 
 ## Usage
 
+> 💡 **Runnable version:** the examples below live as a runnable program in
+> [`samples/NTypeForge.Sample`](samples/NTypeForge.Sample) — try it with
+> `dotnet run --project samples/NTypeForge.Sample`.
+
 ### 1. Pass a structurally-matching type to a method
 
 This is the headline feature shown above: just call the method. If the argument's

--- a/samples/NTypeForge.Sample/Domain.cs
+++ b/samples/NTypeForge.Sample/Domain.cs
@@ -1,0 +1,44 @@
+namespace NTypeForge.Sample;
+
+// None of these concrete types declare ': ICalculator' or ': ILogger' - they only *structurally*
+// match the interfaces, which is all NTypeForge needs to bridge them at compile time.
+
+public interface ICalculator
+{
+    float Calculate(float a, float b);
+}
+
+public interface ILogger
+{
+    void Log(string message);
+}
+
+// Structurally an ICalculator, without declaring it.
+public sealed class AddCalculator
+{
+    public float Calculate(float a, float b) => a + b;
+}
+
+// Structurally an ILogger.
+public sealed class ConsoleLogger
+{
+    public void Log(string message) => Console.WriteLine($"   [log] {message}");
+}
+
+// Its methods expect the interfaces above; callers pass the bare concrete types and NTypeForge
+// generates the bridging overloads.
+public sealed class CalculatorManager
+{
+    public float HandleCalculate(ICalculator calculator, float a, float b)
+        => calculator.Calculate(a, b);
+
+    public static float HandleCalculateStatic(ICalculator calculator, float a, float b)
+        => calculator.Calculate(a, b) * 2;
+
+    public float HandleBoth(ICalculator calculator, ILogger logger, float a, float b)
+    {
+        float result = calculator.Calculate(a, b);
+        logger.Log($"{a} + {b} = {result}");
+        return result;
+    }
+}

--- a/samples/NTypeForge.Sample/NTypeForge.Sample.csproj
+++ b/samples/NTypeForge.Sample/NTypeForge.Sample.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <!-- Consume NTypeForge from source exactly as a package consumer would: the runtime library plus
+       the source generator wired in as an analyzer (no runtime assembly). This is the two-reference
+       shape documented in the README's Installation section. -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\NTypeForge\NTypeForge.csproj" />
+    <ProjectReference Include="..\..\src\NTypeForge.SourceGenerator\NTypeForge.SourceGenerator.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/samples/NTypeForge.Sample/Program.cs
+++ b/samples/NTypeForge.Sample/Program.cs
@@ -1,0 +1,48 @@
+using NTypeForge;
+
+namespace NTypeForge.Sample;
+
+// The README's calculator example as a runnable program. None of the concrete types in Domain.cs
+// implement the interfaces they are used as - NTypeForge's source generator bridges them
+// structurally at compile time (no reflection, no hand-written adapters). Run it with:
+//
+//     dotnet run --project samples/NTypeForge.Sample
+internal static class Program
+{
+    private static void Main()
+    {
+        Console.WriteLine("== NTypeForge sample ==");
+        Console.WriteLine();
+
+        var manager = new CalculatorManager();
+
+        // 1. Implicit ducking: pass a structurally-matching type straight into a method that expects
+        //    the interface. The generator emits an overload that accepts the concrete type.
+        float sum = manager.HandleCalculate(new AddCalculator(), 10, 20);
+        Console.WriteLine($"1. HandleCalculate(AddCalculator, 10, 20)           = {sum}");
+
+        //    Static methods duck the same way.
+        float doubled = CalculatorManager.HandleCalculateStatic(new AddCalculator(), 2, 3);
+        Console.WriteLine($"   HandleCalculateStatic(AddCalculator, 2, 3)       = {doubled}");
+
+        //    Several arguments are bridged in one call - each argument gets its own proxy.
+        float both = manager.HandleBoth(new AddCalculator(), new ConsoleLogger(), 10, 20);
+        Console.WriteLine($"   HandleBoth(AddCalculator, ConsoleLogger, 10, 20) = {both}");
+
+        // 2. Explicit proxy: Duck<T>() hands back a value that *is* a T, to store or pass around.
+        ICalculator calc = new AddCalculator().Duck<ICalculator>();
+        Console.WriteLine();
+        Console.WriteLine($"2. Duck<ICalculator>().Calculate(10, 20)            = {calc.Calculate(10, 20)}");
+
+        // 3. Recover the original instance - every generated proxy implements IProxy<T>.
+        var original = new AddCalculator();
+        ICalculator proxy = original.Duck<ICalculator>();
+        Console.WriteLine();
+        Console.WriteLine($"3. Unbox<AddCalculator>() == original               = {ReferenceEquals(original, proxy.Unbox<AddCalculator>())}");
+        if (proxy is IProxy<AddCalculator> wrapper)
+            Console.WriteLine($"   IProxy<AddCalculator>.Inner == original          = {ReferenceEquals(original, wrapper.Inner)}");
+
+        Console.WriteLine();
+        Console.WriteLine("Every bridge above was generated at compile time.");
+    }
+}

--- a/tests/NTypeForge.Tests/MultipleArgumentDuckingTests.cs
+++ b/tests/NTypeForge.Tests/MultipleArgumentDuckingTests.cs
@@ -8,6 +8,7 @@ namespace NTypeForge.Tests;
 
 public interface ISummer { int Sum(int a, int b); }
 public interface IStamper { string Stamp(string text); }
+public interface IShouter { string Shout(string text); }
 
 // Structurally identical to ISummer; used to hand an already-proxied value into a call that
 // needs it re-ducked to ISummer.
@@ -15,6 +16,7 @@ public interface IOtherSummer { int Sum(int a, int b); }
 
 public class PlainSummer { public int Sum(int a, int b) => a + b; }
 public class PlainStamper { public string Stamp(string text) => $"[{text}]"; }
+public class PlainShouter { public string Shout(string text) => text + "!"; }
 
 public class Pipeline
 {
@@ -29,6 +31,10 @@ public class Pipeline
 
     public string RunThree(ISummer summer, string sep, IStamper stamper, IStamper again)
         => again.Stamp(stamper.Stamp(summer.Sum(2, 3).ToString()) + sep);
+
+    // Three *distinct* ducked interfaces (ISummer, IStamper, IShouter) bridged in one call.
+    public string RunThreeDistinct(ISummer summer, IStamper stamper, IShouter shouter)
+        => shouter.Shout(stamper.Stamp(summer.Sum(2, 3).ToString()));
 }
 
 public class MultipleArgumentDuckingTests
@@ -63,6 +69,18 @@ public class MultipleArgumentDuckingTests
         var result = new Pipeline().RunThree(new PlainSummer(), "!", new PlainStamper(), new PlainStamper());
 
         Assert.Equal("[[5]!]", result);
+    }
+
+    // Three different interfaces ducked in a single call - one proxy per argument, each matched to
+    // its own concrete type. Proves multi-argument ducking is neither limited to two arguments nor
+    // to repeats of one interface (RunThree reuses IStamper): here ISummer, IStamper and IShouter
+    // are all distinct, so three different proxies are generated and wrapped in one forwarding call.
+    [Fact]
+    public void DucksThreeDistinctInterfacesInOneCall()
+    {
+        var result = new Pipeline().RunThreeDistinct(new PlainSummer(), new PlainStamper(), new PlainShouter());
+
+        Assert.Equal("[5]!", result);
     }
 
     [Fact]


### PR DESCRIPTION
Two small additions that strengthen the multi-argument ducking story.

## 1. Runnable sample — `samples/NTypeForge.Sample`

The README's calculator example as real, buildable code — the best "does this actually work?" signal for a newcomer. Demonstrates all three usage modes end to end:
- **Implicit argument ducking** — pass a structurally-matching concrete type straight into a method expecting the interface: instance (`HandleCalculate`), `static` (`HandleCalculateStatic`), and two arguments bridged at once (`HandleBoth(AddCalculator, ConsoleLogger, …)`).
- **Explicit `Duck<T>()`** — get the interface value itself.
- **Recovery** — `Unbox<AddCalculator>()` and `IProxy<AddCalculator>.Inner` to get the original instance back.

None of the concrete types (`AddCalculator`, `ConsoleLogger`) declare the interfaces — NTypeForge bridges them structurally at compile time.

Notes:
- Consumes NTypeForge **from source with the two-reference (runtime + analyzer) shape** a package consumer uses, so it doubles as a worked installation example.
- **Wired into `NTypeForge.slnx`**, so the `build` job compiles it (runs the generator over it) — the verification here, since there's no local SDK. Built but not executed (not a test project).
- Linked from the README **Usage** section (`dotnet run --project samples/NTypeForge.Sample`).
- `IsPackable` stays at the repo default (`false`), so it's never packed.

## 2. Test — three *distinct* ducked interfaces in one call

`MultipleArgumentDuckingTests.DucksThreeDistinctInterfacesInOneCall`. The existing `RunThree` already ducks three arguments, but two of them share `IStamper`. The new `RunThreeDistinct(ISummer, IStamper, IShouter)` makes all three interfaces different — one proxy per argument, each matched to its own concrete type — pinning that multi-argument ducking is neither capped at two arguments nor reliant on repeating a single interface. Compile-time (generator emits the three-proxy forwarding overload) **and** runtime (asserts `"[5]!"`) are both exercised by the `build` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7W1dyFLg9YmH8GpCiG7Cs