### PR TITLE
Add NTF004 (ref/out/in duck near-miss warning) + async coverage + diagnostics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,26 +441,25 @@ When `Duck<T>()` targets an interface with an unsupported member it reports
 high-confidence near-miss, where it emits the [NTF003](#diagnostics) warning to
 explain why duck typing didn't kick in.
 
-### When implicit ducking is silently skipped
+### When implicit ducking can't bridge a call
 
 An *implicit* call (one without `Duck<T>()`) is rewired only when there is exactly one
-unambiguous way to bridge it. Otherwise NTypeForge deliberately leaves the call alone
-**and reports no diagnostic** — you get the compiler's normal overload-resolution error
-(typically `CS1503`), exactly as if NTypeForge weren't referenced. This avoids masking
-the real error or guessing wrong:
+unambiguous way to bridge it. When it can't be, NTypeForge errs toward silence so it never
+masks the compiler's own overload-resolution error (typically `CS1503`):
 
-- **The ducked argument is passed by `ref`/`out`/`in`.** Ducking substitutes a freshly
-  constructed proxy for the argument, which is valid only for a by-value parameter; a
-  `ref`/`out`/`in` parameter needs a real variable of the exact type. (This is about the
-  argument *being* ducked — a `ref`/`out`/`in` parameter sitting *alongside* a ducked
-  argument is forwarded untouched, and `ref`/`out`/`in` parameters on the interface's own
-  methods are fully supported.)
+- **The ducked argument is passed by `ref`/`out`/`in`.** A generated proxy can't be passed
+  by reference (a `ref`/`out`/`in` parameter needs a real variable of the exact type), so
+  the argument can't be ducked. When it *structurally matches* the interface — a true
+  near-miss — this is surfaced as the [NTF004](#diagnostics) warning, explaining why an
+  otherwise-matching type was rejected. (This is the argument *being* ducked; a
+  `ref`/`out`/`in` parameter *alongside* a ducked argument is forwarded untouched, and
+  `ref`/`out`/`in` parameters on the interface's own methods are fully supported.)
 - **The call is ambiguous.** If a value structurally matches more than one candidate
   interface — say two overloads each taking a different interface it fits — picking one
-  would be arbitrary, so the call is left for you to disambiguate.
+  would be arbitrary, so the call is left **silent** for you to disambiguate.
 - **The match is incomplete.** If the concrete is missing a required member — including
-  just one argument of a multi-argument call — the site isn't bridged, since a forwarding
-  call that ducked only the matching arguments could never bind.
+  just one argument of a multi-argument call — the site isn't bridged (a forwarding call
+  that ducked only the matching arguments could never bind), and no diagnostic is raised.
 
 An explicit `Duck<T>()` is the deliberate opposite: because you asked for the conversion
 by name, a missing member is a hard [NTF001](#diagnostics) error rather than silence.
@@ -474,6 +473,7 @@ by name, a missing member is a hard [NTF001](#diagnostics) error rather than sil
 | **NTF001** | Error | `Duck<T>()` was used but the type does not structurally implement every member required by `T`. |
 | **NTF002** | Error | A `Duck<T>()` target interface contains a member NTypeForge cannot proxy (e.g. a `static abstract` member). |
 | **NTF003** | Warning | An implicit call's argument structurally matches the parameter interface *except* for an unsupported member, so NTypeForge couldn't bridge it — surfaced to explain why the call still fails, without masking the compiler's own error. |
+| **NTF004** | Warning | An implicit call's argument structurally matches the parameter interface, but the parameter is `ref`/`out`/`in`, so a generated proxy can't be passed — surfaced to explain why an otherwise-matching type couldn't be ducked. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -441,6 +441,30 @@ When `Duck<T>()` targets an interface with an unsupported member it reports
 high-confidence near-miss, where it emits the [NTF003](#diagnostics) warning to
 explain why duck typing didn't kick in.
 
+### When implicit ducking is silently skipped
+
+An *implicit* call (one without `Duck<T>()`) is rewired only when there is exactly one
+unambiguous way to bridge it. Otherwise NTypeForge deliberately leaves the call alone
+**and reports no diagnostic** — you get the compiler's normal overload-resolution error
+(typically `CS1503`), exactly as if NTypeForge weren't referenced. This avoids masking
+the real error or guessing wrong:
+
+- **The ducked argument is passed by `ref`/`out`/`in`.** Ducking substitutes a freshly
+  constructed proxy for the argument, which is valid only for a by-value parameter; a
+  `ref`/`out`/`in` parameter needs a real variable of the exact type. (This is about the
+  argument *being* ducked — a `ref`/`out`/`in` parameter sitting *alongside* a ducked
+  argument is forwarded untouched, and `ref`/`out`/`in` parameters on the interface's own
+  methods are fully supported.)
+- **The call is ambiguous.** If a value structurally matches more than one candidate
+  interface — say two overloads each taking a different interface it fits — picking one
+  would be arbitrary, so the call is left for you to disambiguate.
+- **The match is incomplete.** If the concrete is missing a required member — including
+  just one argument of a multi-argument call — the site isn't bridged, since a forwarding
+  call that ducked only the matching arguments could never bind.
+
+An explicit `Duck<T>()` is the deliberate opposite: because you asked for the conversion
+by name, a missing member is a hard [NTF001](#diagnostics) error rather than silence.
+
 ---
 
 ## Diagnostics

--- a/src/NTypeForge.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/src/NTypeForge.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 NTF001 | NTypeForge | Error | No structural match for Duck<T>.
 NTF002 | NTypeForge | Error | Unsupported interface member for duck typing.
 NTF003 | NTypeForge | Warning | Type structurally matches but cannot be implicitly duck-typed.
+NTF004 | NTypeForge | Warning | Type structurally matches but cannot be implicitly duck-typed through a ref/out/in parameter.

--- a/src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs
+++ b/src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs
@@ -24,13 +24,20 @@ namespace NTypeForge.SourceGenerator
             public readonly ITypeSymbol UnderlyingType;
             public readonly ITypeSymbol InterfaceType;
             public readonly int EmittedIndex;
+            // Set only for a ref/out/in near-miss (NTF004): the structural match is blocked because
+            // the parameter is by-reference. Null on a normal (duckable) argument.
+            public readonly string? RefKindBlocker;
+            public readonly string? BlockedParameterName;
 
-            public DuckedArgSite(ITypeSymbol argType, ITypeSymbol underlyingType, ITypeSymbol interfaceType, int emittedIndex)
+            public DuckedArgSite(ITypeSymbol argType, ITypeSymbol underlyingType, ITypeSymbol interfaceType, int emittedIndex,
+                string? refKindBlocker = null, string? blockedParameterName = null)
             {
                 ArgType = argType;
                 UnderlyingType = underlyingType;
                 InterfaceType = interfaceType;
                 EmittedIndex = emittedIndex;
+                RefKindBlocker = refKindBlocker;
+                BlockedParameterName = blockedParameterName;
             }
         }
 
@@ -47,7 +54,8 @@ namespace NTypeForge.SourceGenerator
             // resolution (Symbol == null, with candidates) can be rescued by generated proxies.
             if (symbolInfo.Symbol != null || symbolInfo.CandidateSymbols.Length == 0) return null;
 
-            return TryGetMethodArgumentDuck(invocation, semanticModel, symbolInfo, cancellationToken);
+            return TryGetMethodArgumentDuck(invocation, semanticModel, symbolInfo, cancellationToken)
+                ?? TryGetRefKindNearMiss(invocation, semanticModel, symbolInfo, cancellationToken);
         }
 
         // Matches the top-level `NTypeForge` namespace only, so a user's unrelated
@@ -259,6 +267,131 @@ namespace NTypeForge.SourceGenerator
 
             resolved.Sort((a, b) => a.EmittedIndex.CompareTo(b.EmittedIndex));
             return resolved;
+        }
+
+        // NTF004 - a ref/out/in near-miss. Runs only when the normal duck path found nothing: the
+        // argument may still be a *structural* match that simply can't be ducked because its
+        // parameter is by-reference (a generated proxy can't be passed by ref/out/in). We surface
+        // that, and only that, as a warning - mirroring NTF003's high-confidence bar: every other
+        // argument must already bind, so the ref kind is the sole blocker, and exactly one candidate
+        // overload may qualify (otherwise the call is genuinely ambiguous and we stay silent).
+        private static CandidateModel? TryGetRefKindNearMiss(
+            InvocationExpressionSyntax invocation, SemanticModel semanticModel, SymbolInfo symbolInfo,
+            CancellationToken cancellationToken)
+        {
+            if (invocation.Expression is not MemberAccessExpressionSyntax) return null;
+
+            var arguments = invocation.ArgumentList.Arguments;
+            var argFacts = new ArgumentDuckFact?[arguments.Count];
+
+            (IMethodSymbol Candidate, List<DuckedArgSite> Blocked)? only = null;
+            foreach (var candidate in symbolInfo.CandidateSymbols.OfType<IMethodSymbol>())
+            {
+                if (candidate.ContainingType == null) continue;
+                var blocked = CollectRefKindNearMiss(semanticModel, candidate, arguments, argFacts, cancellationToken);
+                if (blocked == null) continue;
+                if (only != null) return null; // more than one near-miss interpretation: ambiguous, stay silent
+                only = (candidate, blocked);
+            }
+            if (only == null) return null;
+
+            var (chosen, blockedSites) = only.Value;
+            var target = GetForwardingTarget(invocation, semanticModel, chosen, cancellationToken);
+            if (target == null || ContainsTypeParameter(target) || !IsUsableFromGeneratedTopLevelCode(target))
+                return null;
+
+            return BuildModel(
+                invocation, target, blockedSites,
+                isStatic: chosen.IsStatic && !IsExtensionLike(chosen),
+                isDuckCall: false,
+                originalMethod: chosen);
+        }
+
+        // A candidate overload is a clean ref-kind near-miss when at least one argument maps to a
+        // ref/out/in interface parameter whose underlying type structurally satisfies it, and every
+        // other argument already binds. Returns the blocked sites, or null when it is not such a
+        // near-miss (so the call is left alone with no diagnostic).
+        private static List<DuckedArgSite>? CollectRefKindNearMiss(
+            SemanticModel semanticModel, IMethodSymbol candidate, SeparatedSyntaxList<ArgumentSyntax> arguments,
+            ArgumentDuckFact?[] argFacts, CancellationToken cancellationToken)
+        {
+            if (!TryMapArgumentsToParameters(arguments, candidate, out var parameterIndices)) return null;
+
+            var blocked = new List<DuckedArgSite>();
+            for (int syntaxIndex = 0; syntaxIndex < arguments.Count; syntaxIndex++)
+            {
+                var paramIndex = parameterIndices[syntaxIndex];
+                if (paramIndex < 0) return null;
+                var parameter = candidate.Parameters[paramIndex];
+                var expression = arguments[syntaxIndex].Expression;
+
+                if (IsRefKindInterfaceParameter(parameter))
+                {
+                    var site = TryBuildRefKindBlocker(
+                        semanticModel, candidate, parameter, paramIndex, expression, argFacts, syntaxIndex, cancellationToken);
+                    if (site == null) return null;
+                    blocked.Add(site.Value);
+                }
+                else if (!BindsImplicitly(semanticModel, expression, parameter.Type))
+                {
+                    return null;
+                }
+            }
+
+            return blocked.Count > 0 ? blocked : null;
+        }
+
+        private static bool IsRefKindInterfaceParameter(IParameterSymbol parameter)
+            => parameter.RefKind != RefKind.None && parameter.Type.TypeKind == TypeKind.Interface;
+
+        // The argument filling a ref/out/in interface parameter, as a blocked DuckedArgSite, when it
+        // is a clean structural match the generated code could name; otherwise null (which makes the
+        // whole overload a non-near-miss, so NTF004 does not fire on it).
+        private static DuckedArgSite? TryBuildRefKindBlocker(
+            SemanticModel semanticModel, IMethodSymbol candidate, IParameterSymbol parameter, int paramIndex,
+            ExpressionSyntax expression, ArgumentDuckFact?[] argFacts, int syntaxIndex, CancellationToken cancellationToken)
+        {
+            var argFact = argFacts[syntaxIndex] ??= ComputeArgumentDuckFact(semanticModel, expression, cancellationToken);
+            if (argFact.Type == null || argFact.Underlying == null) return null;
+            if (ContainsTypeParameter(argFact.Type) || ContainsTypeParameter(argFact.Underlying) || ContainsTypeParameter(parameter.Type))
+                return null;
+            if (!IsUsableFromGeneratedTopLevelCode(argFact.Underlying) || !IsUsableFromGeneratedTopLevelCode(parameter.Type))
+                return null;
+            if (!StructurallyMatches(parameter.Type, argFact.Underlying))
+                return null;
+
+            return new DuckedArgSite(
+                argFact.Type, argFact.Underlying, parameter.Type, EmittedParameterIndex(candidate, paramIndex),
+                refKindBlocker: RefKindKeyword(parameter.RefKind), blockedParameterName: parameter.Name);
+        }
+
+        private static bool BindsImplicitly(SemanticModel semanticModel, ExpressionSyntax expression, ITypeSymbol type)
+        {
+            var conversion = semanticModel.ClassifyConversion(expression, type);
+            return conversion.Exists && conversion.IsImplicit;
+        }
+
+        // Whether the underlying type structurally satisfies the interface over a fully-proxyable
+        // contract. An unsupported member is NTF002/NTF003 territory, not a ref-kind near-miss, so it
+        // disqualifies the match here.
+        private static bool StructurallyMatches(ITypeSymbol interfaceType, ITypeSymbol underlyingType)
+        {
+            var requirements = InterfaceRequirementsAnalyzer.Analyze(interfaceType);
+            if (requirements.Unsupported != null) return false;
+            var surfaceSet = new HashSet<string>(SurfaceAnalyzer.BuildSurfaceCompatKeys(underlyingType), StringComparer.Ordinal);
+            return StructuralMatch.IsSatisfiedBy(
+                requirements.Methods, requirements.Properties, requirements.Indexers, requirements.Events, surfaceSet);
+        }
+
+        private static string RefKindKeyword(RefKind kind)
+        {
+            switch (kind)
+            {
+                case RefKind.Ref: return "ref";
+                case RefKind.Out: return "out";
+                case RefKind.In: return "in";
+                default: return "ref readonly";
+            }
         }
 
         private static bool IsExtensionLike(IMethodSymbol method)
@@ -560,7 +693,9 @@ namespace NTypeForge.SourceGenerator
                 eventRequirements: requirements.Events,
                 underlyingSurfaceCompatKeys: surface,
                 isSelfMatch: isSelfMatch,
-                unsupportedMemberName: requirements.Unsupported);
+                unsupportedMemberName: requirements.Unsupported,
+                refKindBlocker: site.RefKindBlocker,
+                blockedParameterName: site.BlockedParameterName);
         }
 
         private static IEnumerable<IParameterSymbol> ForwardedParameters(IMethodSymbol method)

--- a/src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs
+++ b/src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs
@@ -43,6 +43,20 @@ namespace NTypeForge.SourceGenerator
             defaultSeverity: DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
+        // Implicit (no Duck<T>) near-miss of a different kind: the argument structurally matches the
+        // parameter interface, but the parameter is ref/out/in, so a generated proxy can't be passed
+        // (a by-reference parameter needs a real variable of the exact type). Warning, not error -
+        // the user's own call-resolution error already stands; this only explains why duck typing
+        // couldn't bridge an otherwise-matching type. Fired only at a clean near-miss site (see
+        // CandidateAnalyzer.TryGetRefKindNearMiss), so it does not fire on ordinary type errors.
+        private static readonly DiagnosticDescriptor RefKindBlockedImplicitDuck = new DiagnosticDescriptor(
+            id: "NTF004",
+            title: "Type structurally matches but cannot be implicitly duck-typed through a by-reference parameter",
+            messageFormat: "Type '{0}' structurally matches '{1}' but cannot be implicitly duck-typed: parameter '{2}' is passed by '{3}', and a generated proxy cannot be passed by reference",
+            category: "NTypeForge",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
             // The transform resolves every duck-typing site into a value-equatable CandidateModel
@@ -67,11 +81,19 @@ namespace NTypeForge.SourceGenerator
                                    (c.IsDuckCall && c.DuckedArgs.Any(a => !a.IsSelfMatch)));
             context.RegisterSourceOutput(diagnosticCandidates, static (spc, candidate) => ReportDiagnostic(spc, candidate));
 
+            // A structural match blocked only by a ref/out/in parameter can never be ducked (a proxy
+            // can't be passed by reference), but it is a high-confidence near-miss worth a warning.
+            // Disjoint from the branch above (no unsupported member, not a Duck<T> call) and from
+            // emit below (the RefKindBlocker flag excludes it there).
+            var refKindCandidates = candidates
+                .Where(static c => c.DuckedArgs.Any(a => a.RefKindBlocker != null && a.IsSelfMatch));
+            context.RegisterSourceOutput(refKindCandidates, static (spc, candidate) => ReportRefKindNearMiss(spc, candidate));
+
             // Codegen compares by CodegenKey (location ignored): the emitted code does not depend
             // on where a site sits, so an edit that merely moves one (whitespace, unrelated code
             // above it) must not invalidate the collected array and re-emit every generated file.
             var emitCandidates = candidates
-                .Where(static c => c.DuckedArgs.All(a => a.UnsupportedMemberName == null && a.IsSelfMatch))
+                .Where(static c => c.DuckedArgs.All(a => a.UnsupportedMemberName == null && a.IsSelfMatch && a.RefKindBlocker == null))
                 .WithComparer(CandidateModel.CodegenComparer);
             context.RegisterSourceOutput(emitCandidates.Collect(), static (spc, models) => Execute(spc, models));
         }
@@ -168,6 +190,21 @@ namespace NTypeForge.SourceGenerator
         private static bool HasInstanceRequirements(DuckedArgModel arg)
             => arg.MethodRequirements.Count > 0 || arg.PropertyRequirements.Count > 0 ||
                arg.IndexerRequirements.Count > 0 || arg.EventRequirements.Count > 0;
+
+        // One NTF004 per ref/out/in-blocked argument of a near-miss site, naming the type, the
+        // interface it structurally matches, the blocking parameter, and its ref kind.
+        private static void ReportRefKindNearMiss(SourceProductionContext context, CandidateModel candidate)
+        {
+            foreach (var arg in candidate.DuckedArgs)
+            {
+                if (arg.RefKindBlocker != null && arg.IsSelfMatch)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        RefKindBlockedImplicitDuck, candidate.ToLocation(),
+                        arg.UnderlyingFq, arg.InterfaceFq, arg.BlockedParameterName, arg.RefKindBlocker));
+                }
+            }
+        }
 
         private static void RegisterInterface(Dictionary<string, InterfaceInfo> interfaceInfo, DuckedArgModel arg)
         {

--- a/src/NTypeForge.SourceGenerator/Models/DuckedArgModel.cs
+++ b/src/NTypeForge.SourceGenerator/Models/DuckedArgModel.cs
@@ -45,6 +45,12 @@ namespace NTypeForge.SourceGenerator.Models
         // names the offending member for the NTF002/NTF003 diagnostics.
         public string? UnsupportedMemberName { get; }
 
+        // Set only for a ref/out/in near-miss (NTF004): the argument structurally matches the
+        // interface, but the parameter is by-reference, so a generated proxy can't be passed. Holds
+        // the offending parameter's ref kind ("ref"/"out"/"in") and name for the diagnostic message.
+        public string? RefKindBlocker { get; }
+        public string? BlockedParameterName { get; }
+
         // Canonical key folded into CandidateModel.Key. Includes every field that affects the
         // generated output or a reported diagnostic.
         public string Key { get; }
@@ -59,7 +65,8 @@ namespace NTypeForge.SourceGenerator.Models
             IReadOnlyList<IndexerSig> indexerRequirements,
             IReadOnlyList<EventSig> eventRequirements,
             IReadOnlyList<string> underlyingSurfaceCompatKeys,
-            bool isSelfMatch, string? unsupportedMemberName)
+            bool isSelfMatch, string? unsupportedMemberName,
+            string? refKindBlocker = null, string? blockedParameterName = null)
         {
             ArgumentIndex = argumentIndex;
             ArgumentIsInterface = argumentIsInterface;
@@ -78,6 +85,8 @@ namespace NTypeForge.SourceGenerator.Models
             UnderlyingSurfaceCompatKeys = underlyingSurfaceCompatKeys;
             IsSelfMatch = isSelfMatch;
             UnsupportedMemberName = unsupportedMemberName;
+            RefKindBlocker = refKindBlocker;
+            BlockedParameterName = blockedParameterName;
             Key = BuildKey();
         }
 
@@ -92,7 +101,8 @@ namespace NTypeForge.SourceGenerator.Models
                 ArgumentIndex, ArgumentFq, ArgumentIsInterface,
                 UnderlyingFq, UnderlyingIsInterface, UnderlyingBaseDepth,
                 InterfaceFq, reqs, props, idxs, evts, surface,
-                IsSelfMatch, UnsupportedMemberName ?? "");
+                IsSelfMatch, UnsupportedMemberName ?? "",
+                RefKindBlocker ?? "", BlockedParameterName ?? "");
         }
     }
 }

--- a/tests/NTypeForge.Generator.Tests/CodegenValidityTests.cs
+++ b/tests/NTypeForge.Generator.Tests/CodegenValidityTests.cs
@@ -24,6 +24,35 @@ public class CodegenValidityTests
     }
 
     [Fact]
+    public void AsyncReturningMembers_EmitCompilableCode()
+    {
+        // Task / Task<T> / ValueTask<T> are ordinary return types to the proxy; this pins that the
+        // forwarding members emitted for them parse and bind (the generator adds no async/await).
+        const string source = """
+            using System.Threading.Tasks;
+            using NTypeForge;
+            namespace T
+            {
+                public interface IAsyncWorker
+                {
+                    Task RunAsync();
+                    Task<int> ComputeAsync(int seed);
+                    ValueTask<string> DescribeAsync(string name);
+                }
+                public class Worker
+                {
+                    public Task RunAsync() => Task.CompletedTask;
+                    public Task<int> ComputeAsync(int seed) => Task.FromResult(seed);
+                    public ValueTask<string> DescribeAsync(string name) => new(name);
+                }
+                public class C { public void M() { var x = new Worker().Duck<IAsyncWorker>(); } }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    [Fact]
     public void MethodArgumentDucking_EmitsCompilableCode()
     {
         const string source = """

--- a/tests/NTypeForge.Generator.Tests/DiagnosticTests.cs
+++ b/tests/NTypeForge.Generator.Tests/DiagnosticTests.cs
@@ -610,4 +610,100 @@ public class DiagnosticTests
         Assert.Equal(1, GeneratorTestHarness.GetGeneratorDiagnostics(source).CountDiagnostics("NTF001"));
         Assert.Empty(GeneratorTestHarness.GetEmittedCompileErrors(source));
     }
+
+    // NTF004: a by-reference near-miss. The argument structurally matches the parameter interface,
+    // but the parameter is ref/out/in - a generated proxy can't be passed by reference - so the call
+    // can't be bridged. A Warning explains why an otherwise-matching type was rejected; no proxy is
+    // emitted and the compiler's own ref-kind error still stands.
+    [Fact]
+    public void NTF004_WhenDuckedArgumentIsRef()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Mgr
+                {
+                    public int H(ref ICalc c) => c.Add(1, 2);
+                    public void M() { var m = new Mgr(); var a = new Adder(); m.H(ref a); }
+                }
+            }
+            """;
+
+        var ntf004 = GeneratorTestHarness.GetGeneratorDiagnostics(source).Single(d => d.Id == "NTF004");
+        Assert.Equal(DiagnosticSeverity.Warning, ntf004.Severity);
+        Assert.Contains("'ref'", ntf004.GetMessage());
+        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
+        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    [Fact]
+    public void NTF004_WhenDuckedArgumentIsOut()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Mgr
+                {
+                    public void H(out ICalc c) => c = null;
+                    public void M() { var m = new Mgr(); Adder a; m.H(out a); }
+                }
+            }
+            """;
+
+        var ntf004 = GeneratorTestHarness.GetGeneratorDiagnostics(source).Single(d => d.Id == "NTF004");
+        Assert.Equal(DiagnosticSeverity.Warning, ntf004.Severity);
+        Assert.Contains("'out'", ntf004.GetMessage());
+        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    [Fact]
+    public void NTF004_WhenDuckedArgumentIsIn()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Mgr
+                {
+                    public int H(in ICalc c) => c.Add(1, 2);
+                    public void M() { var m = new Mgr(); var a = new Adder(); m.H(in a); }
+                }
+            }
+            """;
+
+        var ntf004 = GeneratorTestHarness.GetGeneratorDiagnostics(source).Single(d => d.Id == "NTF004");
+        Assert.Equal(DiagnosticSeverity.Warning, ntf004.Severity);
+        Assert.Contains("'in'", ntf004.GetMessage());
+        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    // No NTF004 when the by-ref argument doesn't even structurally match: that is an ordinary type
+    // error, not a near-miss, so NTypeForge stays completely silent (no diagnostic at all).
+    [Fact]
+    public void NTF004_NotReported_WhenByRefArgumentDoesNotStructurallyMatch()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class NotACalc { public int Other() => 0; }
+                public class Mgr
+                {
+                    public int H(ref ICalc c) => c.Add(1, 2);
+                    public void M() { var m = new Mgr(); var a = new NotACalc(); m.H(ref a); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
+    }
 }

--- a/tests/NTypeForge.Generator.Tests/SilentDuckFailureTests.cs
+++ b/tests/NTypeForge.Generator.Tests/SilentDuckFailureTests.cs
@@ -2,89 +2,16 @@ using Xunit;
 
 namespace NTypeForge.Generator.Tests;
 
-// "Silent" duck-failures: cases where NTypeForge deliberately neither rewires a failed call nor
-// raises an NTF diagnostic, so the user is left with the compiler's own overload-resolution error
-// (the same as if NTypeForge were not referenced). These characterize that contract from the
-// user's side - the generator stays quiet (no NTF00x) AND the original call still fails to compile.
-// If a future change adds an NTF hint for any of these, update the matching test.
+// Cases an *implicit* (non-Duck<T>) call deliberately leaves alone with NO diagnostic at all, so the
+// user is left with the compiler's own overload-resolution error. These characterize that silence
+// from the user's side - no NTF00x AND the original call still fails to compile.
 //
-// The ducked-argument-by-ref/out/in cases are the gap these fill. Ambiguity and partial (multi-arg)
-// matches are already covered from the "no proxy is emitted" angle in DiagnosticTests
-// (AmbiguousMethodArgumentDuck_IsNotRewired, TwoDuckableArguments_OneWithoutMatch_IsNotRewired); the
-// last two tests here add the complementary "the compiler error still stands" assertion.
+// (The ref/out/in near-miss is NOT silent - it warns NTF004; see DiagnosticTests. Ambiguity and
+// partial matches are also covered from the "no proxy emitted" angle in DiagnosticTests
+// (AmbiguousMethodArgumentDuck_IsNotRewired, TwoDuckableArguments_OneWithoutMatch_IsNotRewired);
+// the tests here add the complementary "the compiler error still stands" assertion.)
 public class SilentDuckFailureTests
 {
-    // Ducking substitutes a freshly constructed proxy for the argument expression, which is valid
-    // only for a by-value parameter: a ref/out/in parameter needs a real variable of the exact type
-    // (CandidateAnalyzer.IsDuckableArgument rejects RefKind != None). So the argument is not ducked,
-    // no proxy is emitted, no NTF is raised, and the compiler's ref-kind error stands.
-
-    [Fact]
-    public void RefDuckedArgument_StaysSilent_AndLeavesCompilerError()
-    {
-        const string source = """
-            using NTypeForge;
-            namespace T
-            {
-                public interface ICalc { int Add(int a, int b); }
-                public class Adder { public int Add(int a, int b) => a + b; }
-                public class Mgr
-                {
-                    public int H(ref ICalc c) => c.Add(1, 2);
-                    public void M() { var m = new Mgr(); var a = new Adder(); m.H(ref a); }
-                }
-            }
-            """;
-
-        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
-        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
-        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
-    }
-
-    [Fact]
-    public void OutDuckedArgument_StaysSilent_AndLeavesCompilerError()
-    {
-        const string source = """
-            using NTypeForge;
-            namespace T
-            {
-                public interface ICalc { int Add(int a, int b); }
-                public class Adder { public int Add(int a, int b) => a + b; }
-                public class Mgr
-                {
-                    public void H(out ICalc c) => c = null;
-                    public void M() { var m = new Mgr(); Adder a; m.H(out a); }
-                }
-            }
-            """;
-
-        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
-        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
-        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
-    }
-
-    [Fact]
-    public void InDuckedArgument_StaysSilent_AndLeavesCompilerError()
-    {
-        const string source = """
-            using NTypeForge;
-            namespace T
-            {
-                public interface ICalc { int Add(int a, int b); }
-                public class Adder { public int Add(int a, int b) => a + b; }
-                public class Mgr
-                {
-                    public int H(in ICalc c) => c.Add(1, 2);
-                    public void M() { var m = new Mgr(); var a = new Adder(); m.H(in a); }
-                }
-            }
-            """;
-
-        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
-        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
-        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
-    }
-
     // Ambiguity: the value structurally matches both candidate interfaces, so choosing one overload
     // would be arbitrary - the call is left alone (CandidateAnalyzer keeps a site only when there is
     // exactly one interpretation). No NTF, and the compiler's own error is what the user sees.

--- a/tests/NTypeForge.Generator.Tests/SilentDuckFailureTests.cs
+++ b/tests/NTypeForge.Generator.Tests/SilentDuckFailureTests.cs
@@ -1,0 +1,139 @@
+using Xunit;
+
+namespace NTypeForge.Generator.Tests;
+
+// "Silent" duck-failures: cases where NTypeForge deliberately neither rewires a failed call nor
+// raises an NTF diagnostic, so the user is left with the compiler's own overload-resolution error
+// (the same as if NTypeForge were not referenced). These characterize that contract from the
+// user's side - the generator stays quiet (no NTF00x) AND the original call still fails to compile.
+// If a future change adds an NTF hint for any of these, update the matching test.
+//
+// The ducked-argument-by-ref/out/in cases are the gap these fill. Ambiguity and partial (multi-arg)
+// matches are already covered from the "no proxy is emitted" angle in DiagnosticTests
+// (AmbiguousMethodArgumentDuck_IsNotRewired, TwoDuckableArguments_OneWithoutMatch_IsNotRewired); the
+// last two tests here add the complementary "the compiler error still stands" assertion.
+public class SilentDuckFailureTests
+{
+    // Ducking substitutes a freshly constructed proxy for the argument expression, which is valid
+    // only for a by-value parameter: a ref/out/in parameter needs a real variable of the exact type
+    // (CandidateAnalyzer.IsDuckableArgument rejects RefKind != None). So the argument is not ducked,
+    // no proxy is emitted, no NTF is raised, and the compiler's ref-kind error stands.
+
+    [Fact]
+    public void RefDuckedArgument_StaysSilent_AndLeavesCompilerError()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Mgr
+                {
+                    public int H(ref ICalc c) => c.Add(1, 2);
+                    public void M() { var m = new Mgr(); var a = new Adder(); m.H(ref a); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
+        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
+        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    [Fact]
+    public void OutDuckedArgument_StaysSilent_AndLeavesCompilerError()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Mgr
+                {
+                    public void H(out ICalc c) => c = null;
+                    public void M() { var m = new Mgr(); Adder a; m.H(out a); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
+        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
+        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    [Fact]
+    public void InDuckedArgument_StaysSilent_AndLeavesCompilerError()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class Mgr
+                {
+                    public int H(in ICalc c) => c.Add(1, 2);
+                    public void M() { var m = new Mgr(); var a = new Adder(); m.H(in a); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
+        Assert.DoesNotContain("_Proxy_", GeneratorTestHarness.GetGeneratedText(source));
+        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    // Ambiguity: the value structurally matches both candidate interfaces, so choosing one overload
+    // would be arbitrary - the call is left alone (CandidateAnalyzer keeps a site only when there is
+    // exactly one interpretation). No NTF, and the compiler's own error is what the user sees.
+    [Fact]
+    public void AmbiguousDuck_StaysSilent_AndLeavesCompilerError()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface IA { int Do(); }
+                public interface IB { int Do(); }
+                public class Impl { public int Do() => 1; }
+                public class Mgr
+                {
+                    public void H(IA a) {}
+                    public void H(IB b) {}
+                    public void M() { var m = new Mgr(); m.H(new Impl()); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
+        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+
+    // Partial match: one argument of a multi-argument call has no structural match, so the site is
+    // not bridged as a whole (ducking only the matching argument could never make the call bind).
+    // No NTF, and the compiler's own error stands.
+    [Fact]
+    public void PartialMultiArgumentMatch_StaysSilent_AndLeavesCompilerError()
+    {
+        const string source = """
+            using NTypeForge;
+            namespace T
+            {
+                public interface ICalc { int Add(int a, int b); }
+                public interface ILog { string Log(string m); }
+                public class Adder { public int Add(int a, int b) => a + b; }
+                public class NotALogger { public int Other() => 0; }
+                public class Mgr
+                {
+                    public string H(ICalc c, ILog l) => l.Log(c.Add(1, 2).ToString());
+                    public void M() { var m = new Mgr(); m.H(new Adder(), new NotALogger()); }
+                }
+            }
+            """;
+
+        Assert.Empty(GeneratorTestHarness.GetGeneratorDiagnostics(source));
+        Assert.NotEmpty(GeneratorTestHarness.GetEmittedCompileErrors(source));
+    }
+}

--- a/tests/NTypeForge.Tests/AsyncMemberDuckingTests.cs
+++ b/tests/NTypeForge.Tests/AsyncMemberDuckingTests.cs
@@ -1,0 +1,68 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NTypeForge.Tests;
+
+// Task / Task<T> / ValueTask<T> are ordinary return types as far as a proxy is concerned: it
+// forwards the call and hands back the awaitable untouched (the generator emits no async/await of
+// its own). These tests pin that a structurally-matching type can be ducked to an async-returning
+// interface and awaited through the proxy - both explicitly via Duck<T>() and via implicit
+// argument ducking at a call site.
+public interface IAsyncWorker
+{
+    Task RunAsync();
+    Task<int> ComputeAsync(int seed);
+    ValueTask<string> DescribeAsync(string name);
+}
+
+// Does not declare IAsyncWorker; matches it structurally.
+public class PlainAsyncWorker
+{
+    public bool Ran { get; private set; }
+
+    public Task RunAsync()
+    {
+        Ran = true;
+        return Task.CompletedTask;
+    }
+
+    public Task<int> ComputeAsync(int seed) => Task.FromResult(seed * 2);
+
+    public ValueTask<string> DescribeAsync(string name) => new ValueTask<string>($"worker:{name}");
+}
+
+public class AsyncConsumer
+{
+    public static async Task<int> RunThenComputeAsync(IAsyncWorker worker, int seed)
+    {
+        await worker.RunAsync();
+        return await worker.ComputeAsync(seed);
+    }
+}
+
+public class AsyncMemberDuckingTests
+{
+    [Fact]
+    public async Task ForwardsTaskAndValueTaskMembersThroughProxy()
+    {
+        var original = new PlainAsyncWorker();
+        IAsyncWorker worker = original.Duck<IAsyncWorker>();
+
+        await worker.RunAsync();
+        var computed = await worker.ComputeAsync(21);
+        var described = await worker.DescribeAsync("a");
+
+        Assert.True(original.Ran);            // non-generic Task member actually forwarded and ran
+        Assert.Equal(42, computed);           // Task<int> result flows back through the proxy
+        Assert.Equal("worker:a", described);  // ValueTask<string> result flows back too
+    }
+
+    [Fact]
+    public async Task ImplicitlyDucksConcreteIntoAsyncReturningInterface()
+    {
+        // PlainAsyncWorker doesn't implement IAsyncWorker; the generator bridges it at the call site.
+        var computed = await AsyncConsumer.RunThenComputeAsync(new PlainAsyncWorker(), 21);
+
+        Assert.Equal(42, computed);
+    }
+}


### PR DESCRIPTION
Three related DX improvements to NTypeForge's diagnostics and coverage.

## 1. NTF004 — diagnose the `ref`/`out`/`in` near-miss (`67e764f`)

Previously, an implicit call whose argument *structurally matches* an interface parameter but is passed by `ref`/`out`/`in` failed **silently** — the user got a raw `CS1503` with no hint, even though their type would otherwise duck. A generated proxy can't be passed by reference, so it genuinely can't be bridged — but that's worth *explaining*.

New **NTF004 (Warning)** does exactly that, held to the same high-confidence bar as NTF003:
- Fires only when the argument **structurally matches** the interface and the by-ref parameter is the **sole** blocker (every other argument already binds, exactly one candidate interpretation). So it never fires on ordinary type errors — a non-matching by-ref argument stays completely silent (guard test included).
- A **Warning**, never an error, so it explains the failure without masking the compiler's own.
- Detection lives in `CandidateAnalyzer.TryGetRefKindNearMiss`; the model carries the ref-kind + parameter name (folded into the cache key); near-miss candidates route to a new diagnostic branch and are excluded from emit (they can't be ducked).

**Ambiguity and partial matches remain deliberately silent** — that's an intentional design choice (avoid guessing / avoid restating plain type errors), now pinned by `SilentDuckFailureTests`.

## 2. Async-returning members (`9785647`)

`Task` / `Task<T>` / `ValueTask<T>` are ordinary return types to the proxy, but were untested. Adds a runtime test (`AsyncMemberDuckingTests`, awaited through the proxy via both `Duck<T>()` and implicit ducking) and a codegen-validity case.

## 3. Docs (`e961ee7` + `67e764f`)

README gains a **"When implicit ducking can't bridge a call"** subsection (ref/out/in → NTF004; ambiguous/incomplete → silent) and an **NTF004** row in the Diagnostics table.

## Verification

No local SDK, so CI is the check. Beyond `build` + `dotnet test`, the **`cognitive-complexity`** gate (S3776 ≤ 15) matters here — the new detection was deliberately decomposed into small helpers to stay under it. NTF004 is contained to failing calls with a ref/out/in *interface* parameter, so it won't fire (and trip `TreatWarningsAsErrors`) in the sample or runtime-test projects, whose ref/out/in params are structs or passthroughs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7W1dyFLg9YmH8GpCiG7Cs