### PR TITLE
refactor: code review — named constants, explicit generator lang, field/property consistency, is-not patterns, empty-args fix

### DIFF
--- a/src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs
+++ b/src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs
@@ -53,7 +53,7 @@ namespace NTypeForge.SourceGenerator
         // Matches the top-level `NTypeForge` namespace only, so a user's unrelated
         // `Foo.NTypeForge` namespace is not mistaken for the library's.
         private static bool IsTopLevelNTypeForgeNamespace(INamespaceSymbol? ns)
-            => ns != null && ns.Name == "NTypeForge" && (ns.ContainingNamespace == null || ns.ContainingNamespace.IsGlobalNamespace);
+            => ns != null && ns.Name == "NTypeForge" && ns.ContainingNamespace.IsGlobalNamespace;
 
         // The underlying type kinds NTypeForge can build a proxy around. A `ref struct` is excluded:
         // it can't be a field of the (non-ref) proxy class, can't be a type argument to IProxy<T>, and
@@ -133,7 +133,7 @@ namespace NTypeForge.SourceGenerator
             InvocationExpressionSyntax invocation, SemanticModel semanticModel, SymbolInfo symbolInfo,
             CancellationToken cancellationToken)
         {
-            if (!(symbolInfo.Symbol is IMethodSymbol resolved) || resolved.Name != "Duck" ||
+            if (symbolInfo.Symbol is not IMethodSymbol resolved || resolved.Name != "Duck" ||
                 !IsTopLevelNTypeForgeNamespace(resolved.ContainingNamespace) || resolved.TypeArguments.Length != 1)
                 return null;
 
@@ -181,7 +181,7 @@ namespace NTypeForge.SourceGenerator
         private static ExpressionSyntax? GetDuckInstanceExpression(
             InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
         {
-            if (!(invocation.Expression is MemberAccessExpressionSyntax memberAccess)) return null;
+            if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return null;
 
             var receiver = semanticModel.GetSymbolInfo(memberAccess.Expression, cancellationToken).Symbol;
             if (receiver is ITypeSymbol or INamespaceSymbol) return null;

--- a/src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs
+++ b/src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs
@@ -12,7 +12,7 @@ namespace NTypeForge.SourceGenerator
     // CandidateModel; Initialize triages those models into two disjoint output branches
     // (diagnostics vs. emit set); Execute computes the interface->concrete match map over the
     // emit set and hands the result to ProxyEmitter for rendering.
-    [Generator]
+    [Generator(LanguageNames.CSharp)]
     public class DuckTypingGenerator : IIncrementalGenerator
     {
         private static readonly DiagnosticDescriptor NoStructuralMatch = new DiagnosticDescriptor(

--- a/src/NTypeForge.SourceGenerator/Models/CodegenModels.cs
+++ b/src/NTypeForge.SourceGenerator/Models/CodegenModels.cs
@@ -23,25 +23,27 @@ namespace NTypeForge.SourceGenerator.Models
 
     // The structural requirements of one interface in render-ready primitive form. Built once per
     // interface and consumed by both structural matching (ConcreteSatisfies) and proxy emission.
+    // Mutable properties (not readonly) so callers can use object-initializer syntax.
     internal sealed class InterfaceInfo
     {
-        public string Fq = "";
-        public string MinimalName = "";
-        public IReadOnlyList<MethodSig> MethodRequirements = Array.Empty<MethodSig>();
-        public IReadOnlyList<PropertySig> PropertyRequirements = Array.Empty<PropertySig>();
-        public IReadOnlyList<IndexerSig> IndexerRequirements = Array.Empty<IndexerSig>();
-        public IReadOnlyList<EventSig> EventRequirements = Array.Empty<EventSig>();
+        public string Fq { get; set; } = "";
+        public string MinimalName { get; set; } = "";
+        public IReadOnlyList<MethodSig> MethodRequirements { get; set; } = Array.Empty<MethodSig>();
+        public IReadOnlyList<PropertySig> PropertyRequirements { get; set; } = Array.Empty<PropertySig>();
+        public IReadOnlyList<IndexerSig> IndexerRequirements { get; set; } = Array.Empty<IndexerSig>();
+        public IReadOnlyList<EventSig> EventRequirements { get; set; } = Array.Empty<EventSig>();
     }
 
     // A concrete type that can back a proxy, with the surface keys used to match it against
     // interface requirements.
+    // Mutable properties (not readonly) so callers can use object-initializer syntax.
     internal sealed class ConcreteInfo
     {
-        public string Fq = "";
-        public string Namespace = "";
-        public string MinimalName = "";
-        public int BaseDepth;
-        public HashSet<string> SurfaceKeys = new HashSet<string>(StringComparer.Ordinal);
+        public string Fq { get; set; } = "";
+        public string Namespace { get; set; } = "";
+        public string MinimalName { get; set; } = "";
+        public int BaseDepth { get; set; }
+        public HashSet<string> SurfaceKeys { get; set; } = new HashSet<string>(StringComparer.Ordinal);
     }
 
     // One proxy to emit: an underlying type adapted to an interface, plus the members to

--- a/src/NTypeForge.SourceGenerator/NTypeForge.SourceGenerator.csproj
+++ b/src/NTypeForge.SourceGenerator/NTypeForge.SourceGenerator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/NTypeForge.SourceGenerator/ProxyEmitter.cs
+++ b/src/NTypeForge.SourceGenerator/ProxyEmitter.cs
@@ -34,26 +34,12 @@ namespace NTypeForge.SourceGenerator
             var proxiesByNamespace = new Dictionary<string, List<ProxyDecl>>(StringComparer.Ordinal);
             var added = new HashSet<string>(StringComparer.Ordinal);
 
-            void AddProxy(string uFq, string uNs, string uMin, string iFq, string iMin,
-                IReadOnlyList<MethodSig> mReqs,
-                IReadOnlyList<PropertySig> pReqs,
-                IReadOnlyList<IndexerSig> iReqs,
-                IReadOnlyList<EventSig> eReqs)
-            {
-                if (!added.Add(uFq + "|" + iFq)) return;
-                if (!proxiesByNamespace.TryGetValue(uNs, out var list))
-                {
-                    list = new List<ProxyDecl>();
-                    proxiesByNamespace[uNs] = list;
-                }
-                list.Add(new ProxyDecl(uFq, uNs, uMin, iFq, iMin, mReqs, pReqs, iReqs, eReqs));
-            }
-
             foreach (var item in allExtensions)
             {
                 foreach (var arg in item.DuckedArgs)
                 {
-                    AddProxy(arg.UnderlyingFq, arg.UnderlyingNamespace, arg.UnderlyingMinimalName,
+                    AddProxyDecl(proxiesByNamespace, added,
+                        arg.UnderlyingFq, arg.UnderlyingNamespace, arg.UnderlyingMinimalName,
                         arg.InterfaceFq, arg.InterfaceMinimalName,
                         arg.MethodRequirements, arg.PropertyRequirements, arg.IndexerRequirements, arg.EventRequirements);
                 }
@@ -63,7 +49,8 @@ namespace NTypeForge.SourceGenerator
                 var iface = _interfaceInfo[kvp.Key];
                 foreach (var concrete in kvp.Value)
                 {
-                    AddProxy(concrete.Fq, concrete.Namespace, concrete.MinimalName,
+                    AddProxyDecl(proxiesByNamespace, added,
+                        concrete.Fq, concrete.Namespace, concrete.MinimalName,
                         iface.Fq, iface.MinimalName,
                         iface.MethodRequirements, iface.PropertyRequirements, iface.IndexerRequirements, iface.EventRequirements);
                 }
@@ -90,6 +77,27 @@ namespace NTypeForge.SourceGenerator
                 // the generator.
                 context.AddSource($"{Sanitize(kvp.Key)}_Proxies_{StableHash(kvp.Key)}.g.cs", sb.ToString());
             }
+        }
+
+        // Registers a proxy declaration (underlying -> interface) into the by-namespace map,
+        // skipping duplicates. Extracted from EmitProxies to avoid a capturing local function.
+        private static void AddProxyDecl(
+            Dictionary<string, List<ProxyDecl>> proxiesByNamespace,
+            HashSet<string> added,
+            string uFq, string uNs, string uMin,
+            string iFq, string iMin,
+            IReadOnlyList<MethodSig> mReqs,
+            IReadOnlyList<PropertySig> pReqs,
+            IReadOnlyList<IndexerSig> iReqs,
+            IReadOnlyList<EventSig> eReqs)
+        {
+            if (!added.Add(uFq + "|" + iFq)) return;
+            if (!proxiesByNamespace.TryGetValue(uNs, out var list))
+            {
+                list = new List<ProxyDecl>();
+                proxiesByNamespace[uNs] = list;
+            }
+            list.Add(new ProxyDecl(uFq, uNs, uMin, iFq, iMin, mReqs, pReqs, iReqs, eReqs));
         }
 
         private void EmitExtensions(SourceProductionContext context, List<CandidateModel> allExtensions)
@@ -322,7 +330,11 @@ namespace NTypeForge.SourceGenerator
         {
             if (candidate.OriginalIsExtensionMethod)
             {
-                return $"{candidate.OriginalContainingTypeFq}.{methodName}{typeParams}({receiver}, {args})";
+                // Guard the trailing-comma edge case: when all non-receiver parameters were ducked
+                // and replaced, `args` may be empty. In that case emit just `(receiver)` rather
+                // than the syntactically invalid `(receiver, )`.
+                var argList = string.IsNullOrEmpty(args) ? receiver : $"{receiver}, {args}";
+                return $"{candidate.OriginalContainingTypeFq}.{methodName}{typeParams}({argList})";
             }
 
             var callReceiver = candidate.IsStatic ? targetFullName : receiver;
@@ -380,7 +392,7 @@ namespace NTypeForge.SourceGenerator
                 if (!string.IsNullOrEmpty(constraint)) sb.AppendLine($"            {constraint}");
             }
             sb.AppendLine("        {");
-            sb.AppendLine($"            {ReturnStatement(method.ReturnsVoid, $"__ntf_instance.{name}{typeParams}({argsStr})")}");
+            sb.AppendLine($"            {ReturnStatement(method.ReturnsVoid, $"__ntf_instance.{name}{typeParams}({argsStr})")} ");
             sb.AppendLine("        }");
         }
 
@@ -508,6 +520,8 @@ namespace NTypeForge.SourceGenerator
         // A deterministic SHA-256 hash (truncated to 32 hex chars) for collision resistance.
         // string.GetHashCode is randomized per process, which would break the generator's required
         // determinism; this is stable across runs and platforms.
+        // NOTE: targets netstandard2.0, so SHA256.HashData and Convert.ToHexString are unavailable;
+        // the manual loop is intentional and must not be changed to those APIs.
         private static string StableHash(string value)
         {
             using var sha = global::System.Security.Cryptography.SHA256.Create();

--- a/src/NTypeForge/DuckExtensions.cs
+++ b/src/NTypeForge/DuckExtensions.cs
@@ -8,6 +8,10 @@ namespace NTypeForge;
 /// </summary>
 public static class DuckExtensions
 {
+    // Maximum proxy-chain depth TryUnbox will walk before giving up. Guards pathological
+    // IProxy implementations that cycle back to themselves (e.g. Unwrapped returns `this`).
+    private const int MaxUnboxDepth = 64;
+
     /// <summary>
     /// Recovers the wrapped <typeparamref name="T"/> from a proxy, walking nested proxies. Returns
     /// <c>default</c> if <paramref name="proxy"/> neither is nor wraps a <typeparamref name="T"/>.
@@ -31,7 +35,7 @@ public static class DuckExtensions
     {
         object? current = proxy;
         int guard = 0;
-        while (current is IProxy untypedProxy && guard++ < 64)
+        while (current is IProxy untypedProxy && guard++ < MaxUnboxDepth)
         {
             if (untypedProxy.Unwrapped is T unwrapped)
             {


### PR DESCRIPTION
## Summary

Comprehensive code review of all source, test, bench, and sample files. The following issues were found and fixed across two commits.

---

### Issues fixed

#### 1. Magic number in `DuckExtensions.TryUnbox` (`src/NTypeForge/DuckExtensions.cs`)

The guard limit `64` was a bare magic number. Extracted to `private const int MaxUnboxDepth = 64` with a doc comment explaining its purpose. This gives it a single authoritative location and makes the intent clear in the loop condition.

#### 2. `[Generator]` without explicit language (`src/NTypeForge.SourceGenerator/DuckTypingGenerator.cs`)

`[Generator]` with no argument registers the generator for *all* languages, which means Roslyn may attempt to load it in VB.NET or F# compilations where it has no effect. Changed to `[Generator(LanguageNames.CSharp)]` to be explicit and safe.

#### 3. Mutable public fields on `InterfaceInfo` / `ConcreteInfo` (`src/NTypeForge.SourceGenerator/Models/CodegenModels.cs`)

`InterfaceInfo` and `ConcreteInfo` used raw public fields (`public string Fq = "";`) while every other model type in the codebase uses auto-properties. Changed to `{ get; set; }` auto-properties. Object-initializer call sites are unaffected — the compiler handles both identically — but this removes the inconsistency and prevents accidental field access via reflection patterns that bypass property logic.

#### 4. Old-style negation patterns in `CandidateAnalyzer` (`src/NTypeForge.SourceGenerator/CandidateAnalyzer.cs`)

Two patterns used the pre-C#-9 idiom `!(x is T y)`:
- `TryGetDuckCall`: `if (!(symbolInfo.Symbol is IMethodSymbol resolved) || ...)` → `if (symbolInfo.Symbol is not IMethodSymbol resolved || ...)`
- `GetDuckInstanceExpression`: `if (!(invocation.Expression is MemberAccessExpressionSyntax memberAccess))` → `if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)`

The file already targets LangVersion 10.0, so negation patterns are available. The `is not` form is more readable and is the idiomatic modern C# style.

Also cleaned up `IsTopLevelNTypeForgeNamespace`: the original check was `ns.ContainingNamespace == null || ns.ContainingNamespace.IsGlobalNamespace`. The `== null` branch is redundant because `IsGlobalNamespace` on the Roslyn global namespace object is always `true`, and the global namespace is never `null` in a real compilation. Simplified to `ns.ContainingNamespace.IsGlobalNamespace`.

#### 5. Stray UTF-8 BOM in `NTypeForge.SourceGenerator.csproj` (`src/NTypeForge.SourceGenerator/NTypeForge.SourceGenerator.csproj`)

The file had a leading BOM byte (``). While .NET SDKs tolerate this, it is non-standard for XML files and can cause issues with some tooling. Removed.

#### 6. Capturing local function in `ProxyEmitter.EmitProxies` (`src/NTypeForge.SourceGenerator/ProxyEmitter.cs`)

`EmitProxies` contained a local function `AddProxy` that captured `proxiesByNamespace` and `added` by reference. Hoisted to `private static void AddProxyDecl(...)` taking those as explicit parameters. This makes the data flow explicit, allows future unit testing in isolation, and avoids the implicit capture.

#### 7. Trailing-comma bug in `ProxyEmitter.OriginalCall` for extension methods (`src/NTypeForge.SourceGenerator/ProxyEmitter.cs`)

When generating the forwarding call for a reduced extension method, the code emitted:
```csharp
ContainingType.Method<T>(receiver, args)
```
If `args` is an empty string (all non-receiver parameters are ducked and replaced, leaving nothing to forward verbatim), this produced `Method(receiver, )` — a syntax error. Fixed with an explicit guard:
```csharp
var argList = string.IsNullOrEmpty(args) ? receiver : $"{receiver}, {args}";
```

---

### What was reviewed but NOT changed

- **Security / code injection**: Type names in generated output come from Roslyn `ITypeSymbol.ToDisplayString(FullyQualifiedFormat)`, which always produces legal C# identifiers. No user-controlled string is ever interpolated raw into generated source.
- **`StableHash` SHA-256 per call**: Each call creates and disposes a `SHA256` instance. On .NET 5+ `SHA256.HashData` (static, no disposal) would be cleaner, but the generator targets `netstandard2.0` where that API is unavailable. A comment was added to document this constraint.
- **`ContainsTypeParameter` LINQ in generator**: Uses `.Any(ContainsTypeParameter)` over type arguments. For the netstandard2.0 target a manual loop would be slightly cheaper, but the list is typically 1–3 elements and this is not a hot path in the predicate stage.
- **Test coverage**: All critical paths are well covered by the existing `DiagnosticTests`, `CodegenValidityTests`, `IncrementalCachingTests`, and runtime test projects. No gaps warranting new tests were identified.
- **`Directory.Packages.props` versions**: All pinned to recent, non-floating versions. No issues found.
- **Dead code**: None found. Every public and internal API is used.

## Test plan

- [ ] `dotnet build` succeeds with no warnings (TreatWarningsAsErrors=true)
- [ ] `dotnet test` passes all tests in `NTypeForge.Tests` and `NTypeForge.Generator.Tests`
- [ ] `dotnet build -p:MeasureCognitiveComplexity=true` passes the cognitive-complexity gate
- [ ] `dotnet run --project samples/NTypeForge.Sample` produces expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8E9SvWC1Mr9eNaZ3NoRJe)_